### PR TITLE
Adding support for tidy3d mediums in waveguide simulations

### DIFF
--- a/gplugins/tidy3d/modes.py
+++ b/gplugins/tidy3d/modes.py
@@ -107,9 +107,9 @@ class Waveguide(pydantic.BaseModel):
     wavelength: float | Sequence[float] | Any
     core_width: float
     core_thickness: float
-    core_material: MaterialSpec | td.CustomMedium
-    clad_material: MaterialSpec
-    box_material: MaterialSpec | None = None
+    core_material: MaterialSpec | td.CustomMedium | td.Medium
+    clad_material: MaterialSpec | td.CustomMedium | td.Medium
+    box_material: MaterialSpec | td.CustomMedium | td.Medium | None = None
     slab_thickness: float = 0.0
     clad_thickness: float | None = None
     box_thickness: float | None = None
@@ -169,12 +169,23 @@ class Waveguide(pydantic.BaseModel):
         #         or isinstance(self.core_material, td.CustomMedium)):
         if not hasattr(self, "_waveguide"):
             # To include a dn -> custom medium
-            if isinstance(self.core_material, td.CustomMedium):
+            if isinstance(self.core_material, td.CustomMedium) or isinstance(self.core_material, td.Medium):
                 core_medium = self.core_material
             else:
                 core_medium = get_medium(self.core_material)
-            clad_medium = get_medium(self.clad_material)
-            box_medium = get_medium(self.box_material) if self.box_material else None
+            
+            if isinstance(self.clad_material, td.CustomMedium) or isinstance(self.clad_material, td.Medium):
+                clad_medium = self.clad_material
+            else:
+                clad_medium = get_medium(self.clad_material)
+
+            if self.box_material:
+                if isinstance(self.box_material, td.CustomMedium) or isinstance(self.box_material, td.Medium):
+                    box_medium = self.box_material
+                else:
+                    box_medium = get_medium(self.box_material)
+            else:
+                box_medium = None
 
             freq0 = td.C_0 / np.mean(self.wavelength)
             n_core = core_medium.eps_model(freq0) ** 0.5


### PR DESCRIPTION
It allows specifying a tidy3d medium when simulating a waveguide. This can be useful if we just want to pass a refractive index number instead of a material name.

Right now this fails:

```
a = gt.modes.Waveguide(
    wavelength=1.55, 
    core_width=1.0,
    slab_thickness=0,
    core_material=Medium(permittivity=(2.1)**2), 
    clad_material=Medium(permittivity=(1.448)**2), 
    core_thickness=0.2,
    num_modes=4,
    side_margin=3.0,
    grid_resolution = 20,
)
```

And with this PR it will work