### PR TITLE
Simulation should be periodic in z not y

### DIFF
--- a/gplugins/tidy3d/get_simulation.py
+++ b/gplugins/tidy3d/get_simulation.py
@@ -193,8 +193,8 @@ def get_simulation(
     else:
         boundary_spec = boundary_spec or td.BoundarySpec(
             x=td.Boundary.pml(),
-            y=td.Boundary.periodic(),
-            z=td.Boundary.pml(),
+            y=td.Boundary.pml(),
+            z=td.Boundary.periodic(),
         )
 
     wavelength = (wavelength_start + wavelength_stop) / 2


### PR DESCRIPTION
Since we are placing components in the xy plane the simulation should be infinitely extended (i.e. periodic) in z.
