### PR TITLE
Expose built documentation as artifact

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -131,3 +131,9 @@ jobs:
           GDSFACTORY_DISPLAY_TYPE: klayout
         run: |
           make docs
+      - name: Expose docs artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: docs
+          path: docs/_build/html/


### PR DESCRIPTION
This PR exposes the test_docs built HTML to download. Normal retention policy should apply.

Closes #40 