### PR TITLE
Add linting for Markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
     hooks:
       - id: j2lint
         args: [--ignore, jinja-statements-delimiter, jinja-statements-indentation, --]
+
+  - repo: https://github.com/markdownlint/markdownlint.git
+    rev: v0.12.0
+    hooks:
+      - id: markdownlint
+        args: [--rules, '~MD007,~MD012,~MD013,~MD026,~MD029,~MD033,~MD034']

--- a/docs/plugins_fdtd.md
+++ b/docs/plugins_fdtd.md
@@ -8,9 +8,9 @@ FDTD simulations compute the [Sparameters](https://en.wikipedia.org/wiki/Scatter
 
 gdsfactory provides you a similar python API to drive 3 different FDTD simulators:
 
-  - MEEP
-  - tidy3d
-  - Lumerical Ansys FDTD
+- MEEP
+- tidy3d
+- Lumerical Ansys FDTD
 
 Gdsfactory follows the Sparameters syntax `o1@0,o2@0` where `o1` is the input port `@0` mode 0 (usually fundamental TE mode) and `o2@0` refers to output port `o2` mode 0.
 


### PR DESCRIPTION
Add same Markdown linting as for gdsfactory in https://github.com/gdsfactory/gdsfactory/pull/2001.

To be merged if https://github.com/gdsfactory/gdsfactory/pull/2001 is merged.

Closes #54