### PR TITLE
Add electrostatic simulations using Palace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gdsfactory plugins:
 - `meep` for FDTD.
 - `mpb` for MPB mode solver.
 - `elmer` for electrostatic (capacitive) simulations.
+- `palace` for electrostatic (capacitive) simulations.
 - `web` for gdsfactory webapp.
 
 ## Installation
@@ -40,6 +41,7 @@ The following plugins require special installation without pip:
 
 - For Meep and MPB you need to use `conda` or `mamba` on MacOS, Linux or [Windows WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) with `conda install pymeep=*=mpi_mpich_* -c conda-forge -y`
 - For Elmer, refer to [Elmer FEM – Installation](https://www.elmerfem.org/blog/binaries/) for installation or compilation instructions each platform. Gplugins assumes `ElmerSolver`, `ElmerSolver_mpi`, and `ElmerGrid` are available in your PATH environment variable.
+- For Palace, refer to [Palace – Installation](https://awslabs.github.io/palace/stable/install/) for compilation instructions using Spack or Singularity. Gplugins assumes `palace` is available in your PATH environment variable.
 
 
 ## Getting started

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,6 +21,7 @@ execute:
     - "*ray_optimiser*"
     - "*03_numerical_implantation*"
     - "*02_model_extraction*"
+    - "*palace*"
     # - "*20_schematic_driven_layout*"
     # - "*001_meep_sparameters*"
     # - "*00_tidy3d.ipynb"

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,6 +23,7 @@ parts:
           - file: notebooks/tcad_02_analytical_process
           - file: notebooks/tcad_03_numerical_implantation
           - file: notebooks/elmer_01_electrostatic
+          - file: notebooks/palace_01_electrostatic
       - file: plugins_mode_solver
         sections:
           - file: notebooks/femwell_01_modes

--- a/docs/api_design.rst
+++ b/docs/api_design.rst
@@ -208,3 +208,13 @@ Electrostatics
    :toctree: _autosummary/
 
    run_capacitive_simulation_elmer
+
+
+.. currentmodule:: gplugins.palace
+
+.. rubric:: Palace
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   run_capacitive_simulation_palace

--- a/docs/notebooks/palace_01_electrostatic.py
+++ b/docs/notebooks/palace_01_electrostatic.py
@@ -1,0 +1,172 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.0
+#   kernelspec:
+#     display_name: base
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Electrostatic simulations with Palace
+# Here, we show how Palace may be used to perform electrostatic simulations. For a given geometry, one needs to specify the terminals where to apply potential, similar to {doc}`./elmer_01_electrostatic.py`.
+# This effectively solves the mutual capacitance matrix for the terminals and the capacitance to ground.
+# For details on the physics, see {cite:p}`smolic_capacitance_2021`.
+#
+# ## Installation
+# See [Palace – Installation](https://awslabs.github.io/palace/stable/install/) for installation or compilation instructions. Gplugins assumes `palace` is available in your PATH environment variable.
+#
+# Alternatively, [Singularity / Apptainer](https://apptainer.org/) containers may be used. Instructions for building and an example definition file are found at [Palace – Build using Singularity/Apptainer](https://awslabs.github.io/palace/dev/install/#Build-using-Singularity/Apptainer).
+# Afterwards, an easy install method is to add a script to `~/.local/bin` (or elsewhere in `PATH`) calling the Singularity container. For example, one may create a `palace` file containing
+# ```console
+# #!/bin/bash
+# singularity exec ~/palace.sif /opt/palace/bin/palace "$@"
+# ```
+#
+# ## Geometry, layer config and materials
+
+# %% tags=["hide-input"]
+
+import os
+from math import inf
+from pathlib import Path
+
+import gdsfactory as gf
+import pyvista as pv
+from gdsfactory.components.interdigital_capacitor_enclosed import (
+    interdigital_capacitor_enclosed,
+)
+from gdsfactory.generic_tech import LAYER, get_generic_pdk
+from gdsfactory.technology import LayerStack
+from gdsfactory.technology.layer_stack import LayerLevel
+from IPython.display import display
+
+from gplugins.palace import run_capacitive_simulation_palace
+from gplugins.typings import RFMaterialSpec
+
+gf.config.rich_output()
+PDK = get_generic_pdk()
+PDK.activate()
+
+# %% [markdown]
+# We employ an example LayerStack used in superconducting circuits similar to {cite:p}`marxer_long-distance_2023`.
+
+# %%
+layer_stack = LayerStack(
+    layers=dict(
+        substrate=LayerLevel(
+            layer=LAYER.WAFER,
+            thickness=500,
+            zmin=0,
+            material="Si",
+            mesh_order=99,
+        ),
+        bw=LayerLevel(
+            layer=LAYER.WG,
+            thickness=200e-3,
+            zmin=500,
+            material="Nb",
+            mesh_order=2,
+        ),
+    )
+)
+material_spec: RFMaterialSpec = {
+    "Si": {"relative_permittivity": 11.45},
+    "Nb": {"relative_permittivity": inf},
+    "vacuum": {"relative_permittivity": 1},
+}
+
+# %%
+simulation_box = [[-200, -200], [200, 200]]
+c = gf.Component("capacitance_palace")
+cap = c << interdigital_capacitor_enclosed(
+    metal_layer=LAYER.WG, gap_layer=LAYER.DEEPTRENCH, enclosure_box=simulation_box
+)
+c.add_ports(cap.ports)
+substrate = gf.components.bbox(bbox=simulation_box, layer=LAYER.WAFER)
+c << substrate
+c.flatten()
+
+# %% [markdown]
+# ## Running the simulation
+# ```{eval-rst}
+# We use the function :func:`~run_capacitive_simulation_palace`. This runs the simulation and returns an instance of :class:`~ElectrostaticResults` containing the capacitance matrix and a path to the mesh and the field solutions.
+# ```
+
+# %%
+help(run_capacitive_simulation_palace)
+
+# %% [markdown]
+# ```{eval-rst}
+# .. note::
+#    The meshing parameters and element order shown here are very lax. As such, the computed capacitances are not very accurate.
+# ```
+
+# %%
+results = run_capacitive_simulation_palace(
+    c,
+    layer_stack=layer_stack,
+    material_spec=material_spec,
+    n_processes=1,
+    element_order=1,
+    simulation_folder=Path(os.getcwd()) / "temporary",
+    mesh_parameters=dict(
+        background_tag="vacuum",
+        background_padding=(0,) * 5 + (700,),
+        portnames=c.ports,
+        default_characteristic_length=200,
+        layer_portname_delimiter=(delimiter := "__"),
+        resolutions={
+            "bw": {
+                "resolution": 15,
+            },
+            "substrate": {
+                "resolution": 40,
+            },
+            "vacuum": {
+                "resolution": 40,
+            },
+            **{
+                f"bw{delimiter}{port}": {
+                    "resolution": 20,
+                    "DistMax": 30,
+                    "DistMin": 10,
+                    "SizeMax": 14,
+                    "SizeMin": 3,
+                }
+                for port in c.ports
+            },
+        },
+    ),
+)
+display(results)
+
+# %%
+if results.field_file_location:
+    pv.start_xvfb()
+    pv.set_jupyter_backend("panel")
+    field = pv.read(results.field_file_location)
+    slice = field.slice_orthogonal(z=layer_stack.layers["bw"].zmin * 1e-6)
+
+    p = pv.Plotter()
+    p.add_mesh(slice, scalars="E", cmap="turbo")
+    p.show_grid()
+    p.camera_position = "xy"
+    p.enable_parallel_projection()
+    p.show()
+
+
+# %% [markdown]
+# ## Bibliography
+#
+# ```{bibliography}
+# :style: unsrt
+# :filter: docname in docnames
+# ```

--- a/gplugins/palace/__init__.py
+++ b/gplugins/palace/__init__.py
@@ -1,0 +1,5 @@
+from gplugins.palace.get_capacitance import run_capacitive_simulation_palace
+
+__all__ = [
+    "run_capacitive_simulation_palace",
+]

--- a/gplugins/palace/electrostatic.json
+++ b/gplugins/palace/electrostatic.json
@@ -1,0 +1,69 @@
+{
+  "Problem": {
+    "Type": "Electrostatic",
+    "Verbose": 3,
+    "Output": "postpro"
+  },
+  "Model": {
+    "Mesh": "#MESH",
+    "L0": 1.0e-6
+  },
+  "Domains": {
+    "Materials": [
+      {
+        "Attributes": [
+          6
+        ],
+        "Permittivity": 1
+      },
+      {
+        "Attributes": [
+          5
+        ],
+        "Permittivity": 11.4
+      }
+    ]
+  },
+  "Boundaries": {
+    "Ground": {
+      "Attributes": [
+        7
+      ]
+    },
+    "Terminal": [
+      {
+        "Index": 1,
+        "Attributes": [
+          1
+        ]
+      },
+      {
+        "Index": 2,
+        "Attributes": [
+          2
+        ]
+      },
+      {
+        "Index": 3,
+        "Attributes": [
+          3
+        ]
+      }
+    ],
+    "Postprocessing": {
+      "Capacitance": []
+    }
+  },
+  "Solver": {
+    "Order": 1,
+    "Electrostatic": {
+      "Save": 2
+    },
+    "Linear": {
+      "Type": "BoomerAMG",
+      "KSPType": "CG",
+      "Tol": 1e-8,
+      "MaxIts": 100
+    }
+  }
+}

--- a/gplugins/palace/get_capacitance.py
+++ b/gplugins/palace/get_capacitance.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import inspect
+import itertools
+import json
+import shutil
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from math import inf
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import gdsfactory as gf
+import gmsh
+from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.technology import LayerStack
+from numpy import isfinite
+from pandas import read_csv
+
+from gplugins.typings import ElectrostaticResults, RFMaterialSpec
+
+ELECTROSTATIC_JSON = "electrostatic.json"
+ELECTROSTATIC_TEMPLATE = Path(__file__).parent / ELECTROSTATIC_JSON
+
+
+def _generate_json(
+    simulation_folder: Path,
+    name: str,
+    signals: Sequence[Sequence[str]],
+    bodies: dict[str, dict[str, Any]],
+    ground_layers: Iterable[str],
+    layer_stack: LayerStack,
+    material_spec: RFMaterialSpec,
+    element_order: int,
+    physical_name_to_dimtag_map: dict[str, tuple[int, int]],
+    background_tag: str | None = None,
+    simulator_params: Mapping[str, Any] | None = None,
+):
+    """Generates a json file for capacitive Palace simulations."""
+    # TODO: Generalise to merger with the Elmer implementations"""
+    used_materials = {v.material for v in layer_stack.layers.values()} | (
+        {background_tag} if background_tag else {}
+    )
+    used_materials = {
+        k: material_spec[k]
+        for k in used_materials
+        if isfinite(material_spec[k].get("relative_permittivity", inf))
+    }
+
+    with open(ELECTROSTATIC_TEMPLATE) as fp:
+        palace_json_data = json.load(fp)
+
+    material_to_attributes_map = {
+        v["material"]: physical_name_to_dimtag_map[k][1] for k, v in bodies.items()
+    }
+
+    palace_json_data["Model"]["Mesh"] = f"{name}.msh"
+    palace_json_data["Domains"]["Materials"] = [
+        {
+            "Attributes": [material_to_attributes_map.get(material, None)],
+            "Permittivity": props["relative_permittivity"],
+        }
+        for material, props in used_materials.items()
+    ]
+    # TODO 3d volumes as pec???, not needed for capacitance
+    # palace_json_data['Boundaries']['PEC'] = {
+    #     'Attributes': [
+    #         physical_name_to_dimtag_map[pec][1] for pec in
+    #         (set(k for k, v in physical_name_to_dimtag_map.items() if v[0] == 3) - set(bodies) -
+    #          set(ground_layers))  # TODO same in Elmer??
+    #     ]
+    # }
+    palace_json_data["Boundaries"]["Ground"] = {
+        "Attributes": [physical_name_to_dimtag_map[layer][1] for layer in ground_layers]
+    }
+    palace_json_data["Boundaries"]["Terminal"] = [
+        {
+            "Index": i,
+            "Attributes": [
+                physical_name_to_dimtag_map[signal][1] for signal in signal_group
+            ],
+        }
+        for i, signal_group in enumerate(signals, 1)
+    ]
+    # TODO try do we get energy method without this??
+    palace_json_data["Boundaries"]["Postprocessing"]["Capacitance"] = palace_json_data[
+        "Boundaries"
+    ]["Terminal"]
+
+    palace_json_data["Solver"]["Order"] = element_order
+    palace_json_data["Solver"]["Electrostatic"]["Save"] = len(signals)
+    if simulator_params is not None:
+        palace_json_data["Solver"]["Linear"] |= simulator_params
+
+    with open(simulation_folder / f"{name}.json", "w", encoding="utf-8") as fp:
+        json.dump(palace_json_data, fp, indent=4)
+
+
+def _palace(simulation_folder: Path, name: str, n_processes: int = 1):
+    """Run simulations with Palace."""
+    palace = shutil.which("palace")
+    if palace is None:
+        raise RuntimeError("palace not found. Make sure it is available in your PATH.")
+    json_file = str(simulation_folder / f"{Path(name).stem}.json")
+    with open(simulation_folder / f"{name}_palace.log", "w", encoding="utf-8") as fp:
+        subprocess.run(
+            [palace, json_file]
+            if n_processes == 1
+            else [palace, "-np", str(n_processes), json_file],
+            cwd=simulation_folder,
+            shell=False,
+            stdout=fp,
+            stderr=fp,
+            check=True,
+        )
+
+
+def _read_palace_results(
+    simulation_folder: Path,
+    mesh_filename: str,
+    ports: Iterable[str],
+    is_temporary: bool,
+) -> ElectrostaticResults:
+    """Fetch results from successful Palace simulations."""
+    raw_capacitance_matrix = read_csv(
+        simulation_folder / "postpro" / "terminal-Cm.csv", dtype=float
+    ).values[
+        :, 1:
+    ]  # remove index
+    return ElectrostaticResults(
+        capacitance_matrix={
+            (iname, jname): raw_capacitance_matrix[i][j]
+            for (i, iname), (j, jname) in itertools.product(
+                enumerate(ports), enumerate(ports)
+            )
+        },
+        **(
+            {}
+            if is_temporary
+            else dict(
+                mesh_location=simulation_folder / mesh_filename,
+                field_file_location=simulation_folder
+                / "postpro"
+                / "paraview"
+                / "electrostatic"
+                / "electrostatic.pvd",
+            )
+        ),
+    )
+
+
+def run_capacitive_simulation_palace(
+    component: gf.Component,
+    element_order: int = 1,
+    n_processes: int = 1,
+    layer_stack: LayerStack | None = None,
+    material_spec: RFMaterialSpec | None = None,
+    simulation_folder: Path | str | None = None,
+    simulator_params: Mapping[str, Any] | None = None,
+    mesh_parameters: dict[str, Any] | None = None,
+    mesh_file: Path | str | None = None,
+) -> ElectrostaticResults:
+    """Run electrostatic finite element method simulations using
+    `Palace`_.
+    Returns the field solution and resulting capacitance matrix.
+
+    .. note:: You should have `palace` in your PATH.
+
+    Args:
+        component: Simulation environment as a gdsfactory component.
+        element_order:
+            Order of polynomial basis functions.
+            Higher is more accurate but takes more memory and time to run.
+        n_processes: Number of processes to use for parallelization
+        layer_stack:
+            :class:`~LayerStack` defining defining what layers to include in the simulation
+            and the material properties and thicknesses.
+        material_spec:
+            :class:`~RFMaterialSpec` defining material parameters for the ones used in ``layer_stack``.
+        simulation_folder:
+            Directory for storing the simulation results.
+            Default is a temporary directory.
+        simulator_params: Palace-specific parameters. This will be expanded to ``solver["Linear"]`` in
+            the Palace config, see `Palace documentation <https://awslabs.github.io/palace/stable/config/solver/#solver[%22Linear%22]>`_
+        mesh_parameters:
+            Keyword arguments to provide to :func:`~Component.to_gmsh`.
+        mesh_file: Path to a ready mesh to use. Useful for reusing one mesh file.
+            By default a mesh is generated according to ``mesh_parameters``.
+
+    .. _Palace: https://github.com/awslabs/palace
+    """
+
+    if layer_stack is None:
+        layer_stack = LayerStack(
+            layers={
+                k: LAYER_STACK.layers[k]
+                for k in (
+                    "core",
+                    "substrate",
+                    "box",
+                )
+            }
+        )
+    if material_spec is None:
+        material_spec: RFMaterialSpec = {
+            "si": {"relative_permittivity": 11.45},
+            "sio2": {"relative_permittivity": 1},
+            "vacuum": {"relative_permittivity": 1},
+        }
+
+    temp_dir = TemporaryDirectory()
+    simulation_folder = Path(simulation_folder or temp_dir.name)
+    simulation_folder.mkdir(exist_ok=True, parents=True)
+
+    filename = component.name + ".msh"
+    if mesh_file:
+        shutil.copyfile(str(mesh_file), str(simulation_folder / filename))
+    else:
+        component.to_gmsh(
+            type="3D",
+            filename=simulation_folder / filename,
+            layer_stack=layer_stack,
+            n_threads=n_processes,
+            gmsh_version=2.2,  # see https://mfem.org/mesh-formats/#gmsh-mesh-formats
+            **(mesh_parameters or {}),
+        )
+
+    # re-read the mesh
+    # `interruptible` works on gmsh versions >= 4.11.2
+    gmsh.initialize(
+        **(
+            {"interruptible": False}
+            if "interruptible" in inspect.getfullargspec(gmsh.initialize).args
+            else {}
+        )
+    )
+    gmsh.merge(str(simulation_folder / filename))
+    mesh_surface_entities = {
+        gmsh.model.getPhysicalName(*dimtag)
+        for dimtag in gmsh.model.getPhysicalGroups(dim=2)
+    }
+
+    # Signals are converted to Boundaries
+    ground_layers = {
+        next(k for k, v in layer_stack.layers.items() if v.layer == port.layer)
+        for port in component.get_ports()
+    }  # ports allowed only on metal
+    # TODO infer port delimiter from somewhere
+    port_delimiter = "__"
+    metal_surfaces = [
+        e for e in mesh_surface_entities if any(ground in e for ground in ground_layers)
+    ]
+    # Group signal BCs by ports
+    metal_signal_surfaces_grouped = [
+        [e for e in metal_surfaces if port in e] for port in component.ports
+    ]
+    metal_ground_surfaces = set(metal_surfaces) - set(
+        itertools.chain.from_iterable(metal_signal_surfaces_grouped)
+    )
+
+    ground_layers |= metal_ground_surfaces
+
+    # dielectrics
+    bodies = {
+        k: {
+            "material": v.material,
+        }
+        for k, v in layer_stack.layers.items()
+        if port_delimiter not in k and k not in ground_layers
+    }
+    if background_tag := (mesh_parameters or {}).get("background_tag", "vacuum"):
+        bodies = {**bodies, background_tag: {"material": background_tag}}
+
+    # TODO refactor to not require this map, the same information could be transferred with the variables above
+    physical_name_to_dimtag_map = {
+        gmsh.model.getPhysicalName(*dimtag): dimtag
+        for dimtag in gmsh.model.getPhysicalGroups()
+    }
+    gmsh.finalize()
+
+    _generate_json(
+        simulation_folder,
+        component.name,
+        metal_signal_surfaces_grouped,
+        bodies,
+        ground_layers,
+        layer_stack,
+        material_spec,
+        element_order,
+        physical_name_to_dimtag_map,
+        background_tag,
+        simulator_params,
+    )
+    _palace(simulation_folder, filename, n_processes)
+    results = _read_palace_results(
+        simulation_folder,
+        filename,
+        component.ports,
+        is_temporary=str(simulation_folder) == temp_dir.name,
+    )
+    temp_dir.cleanup()
+    return results

--- a/gplugins/palace/tests/test_palace.py
+++ b/gplugins/palace/tests/test_palace.py
@@ -1,0 +1,139 @@
+from math import inf
+
+import gdsfactory as gf
+import pytest
+from gdsfactory.component import Component
+from gdsfactory.components.interdigital_capacitor_enclosed import (
+    interdigital_capacitor_enclosed,
+)
+from gdsfactory.generic_tech import LAYER
+from gdsfactory.technology import LayerStack
+from gdsfactory.technology.layer_stack import LayerLevel
+
+from gplugins.palace import run_capacitive_simulation_palace
+
+layer_stack = LayerStack(
+    layers=dict(
+        substrate=LayerLevel(
+            layer=LAYER.WAFER,
+            thickness=500,
+            zmin=0,
+            material="Si",
+            mesh_order=99,
+        ),
+        bw=LayerLevel(
+            layer=LAYER.WG,
+            thickness=200e-3,
+            zmin=500,
+            material="Nb",
+            mesh_order=2,
+        ),
+    )
+)
+material_spec = {
+    "Si": {"relative_permittivity": 11.45},
+    "Nb": {"relative_permittivity": inf},
+    "vacuum": {"relative_permittivity": 1},
+}
+
+
+@pytest.fixture
+@gf.cell
+def geometry():
+    simulation_box = [[-200, -200], [200, 200]]
+    c = gf.Component()
+    cap = c << interdigital_capacitor_enclosed(
+        metal_layer=LAYER.WG, gap_layer=LAYER.DEEPTRENCH, enclosure_box=simulation_box
+    )
+    c.add_ports(cap.ports)
+    substrate = gf.components.bbox(bbox=simulation_box, layer=LAYER.WAFER)
+    c << substrate
+    c.flatten()
+    return c
+
+
+def get_reasonable_mesh_parameters(c: Component):
+    return dict(
+        background_tag="vacuum",
+        background_padding=(0,) * 5 + (700,),
+        portnames=c.ports,
+        default_characteristic_length=200,
+        layer_portname_delimiter=(delimiter := "__"),
+        resolutions={
+            "bw": {
+                "resolution": 15,
+            },
+            "substrate": {
+                "resolution": 40,
+            },
+            "vacuum": {
+                "resolution": 40,
+            },
+            **{
+                f"bw{delimiter}{port}": {
+                    "resolution": 20,
+                    "DistMax": 30,
+                    "DistMin": 10,
+                    "SizeMax": 14,
+                    "SizeMin": 3,
+                }
+                for port in c.ports
+            },
+        },
+    )
+
+
+def test_palace_capacitance_simulation_runs(geometry):
+    c = geometry
+    run_capacitive_simulation_palace(
+        c,
+        layer_stack=layer_stack,
+        material_spec=material_spec,
+        mesh_parameters=get_reasonable_mesh_parameters(c),
+    )
+
+
+@pytest.mark.skip(reason="TODO")
+@pytest.mark.parametrize("n_processes", [(1), (2), (4)])
+def test_palace_capacitance_simulation_n_processes(geometry, n_processes):
+    c = geometry
+    run_capacitive_simulation_palace(
+        c,
+        layer_stack=layer_stack,
+        material_spec=material_spec,
+        n_processes=n_processes,
+        mesh_parameters=get_reasonable_mesh_parameters(c),
+    )
+
+
+@pytest.mark.skip(reason="TODO")
+@pytest.mark.parametrize("element_order", [(1), (2), (3)])
+def test_palace_capacitance_simulation_element_order(geometry, element_order):
+    c = geometry
+    run_capacitive_simulation_palace(
+        c,
+        layer_stack=layer_stack,
+        material_spec=material_spec,
+        element_order=element_order,
+        mesh_parameters=get_reasonable_mesh_parameters(c),
+    )
+
+
+@pytest.mark.skip(reason="TODO")
+def test_palace_capacitance_simulation_mesh_size_field(geometry):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_palace_capacitance_simulation_flip_chip(geometry):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_palace_capacitance_simulation_pyvist_plot(geometry):
+    pass
+
+
+@pytest.mark.skip(reason="TODO")
+def test_palace_capacitance_simulation_cdict_form(geometry):
+    pass

--- a/gplugins/palace/tests/test_palace.py
+++ b/gplugins/palace/tests/test_palace.py
@@ -83,6 +83,7 @@ def get_reasonable_mesh_parameters(c: Component):
     )
 
 
+@pytest.mark.skip(reason="Palace not in CI")
 def test_palace_capacitance_simulation_runs(geometry):
     c = geometry
     run_capacitive_simulation_palace(

--- a/gplugins/utils/get_capacitance.py
+++ b/gplugins/utils/get_capacitance.py
@@ -1,0 +1,76 @@
+from collections.abc import Mapping
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import gdsfactory as gf
+from gdsfactory.typings import ComponentSpec
+
+from gplugins.elmer.get_capacitance import run_capacitive_simulation_elmer
+from gplugins.palace.get_capacitance import (
+    run_capacitive_simulation_palace,
+)
+from gplugins.typings import ElectrostaticResults
+
+
+def get_capacitance_path() -> Path:
+    return gf.config.PATH.capacitance
+
+
+def get_capacitance(
+    component: ComponentSpec,
+    simulator: str = "elmer",
+    simulator_params: Mapping[str, Any] | None = None,
+    simulation_folder: Path | str | None = None,
+    **kwargs,
+) -> ElectrostaticResults:
+    """Simulate component with an electrostatic simulation and return capacitance matrix.
+    For more details, see Chapter 2.9 `Capacitance matrix` in `N. Savola, “Design and modelling of long-coherence
+    qubits using energy participation ratios” <http://urn.fi/URN:NBN:fi:aalto-202305213270>`_.
+
+    Args:
+        component: component or component factory.
+        simulator: Simulator to use. The choices are 'elmer' or 'palace'. Both require manual install.
+            This changes the format of ``simulator_params``.
+        simulator_params: Simulator-specific params as a dictionary. See template files for more details.
+            Has reasonable defaults.
+        simulation_folder: Directory for storing the simulation results. Default is a temporary directory.
+        **kwargs: Simulation settings propagated to inner :func:`~run_capacitive_simulation_elmer` or
+            :func:`~run_capacitive_simulation_palace` implementation.
+    """
+    simulation_folder = Path(simulation_folder or get_capacitance_path())
+    component = gf.get_component(component)
+
+    simulation_folder = (
+        simulation_folder / component.function_name
+        if hasattr(component, "function_name")
+        else simulation_folder
+    )
+    simulation_folder.mkdir(exist_ok=True, parents=True)
+
+    match simulator:
+        case "elmer":
+            return run_capacitive_simulation_elmer(
+                component,
+                simulation_folder=simulation_folder,
+                simulator_params=simulator_params,
+                **kwargs,
+            )
+        case "palace":
+            return run_capacitive_simulation_palace(
+                component,
+                simulation_folder=simulation_folder,
+                simulator_params=simulator_params,
+                **kwargs,
+            )
+        case _:
+            raise UserWarning(f"{simulator=!r} not implemented!")
+
+
+get_capacitance_elmer = partial(get_capacitance, tool="elmer")
+get_capacitance_palace = partial(get_capacitance, tool="palace")
+
+
+# if __name__ == "__main__":
+#     c = gf.components.interdigital_capacitor()
+#     print(get_capacitance(c))


### PR DESCRIPTION
This PR adds a plugin for electrostatic simulations using Palace similar to Elmer.
Example is added to documentation alongside simple integration tests. However, these are not yet run in CI, as installing Palace is a bit troublesome. There is no precompiled package and compiling from source in CI would multiply the duration the tests take.

Closes #56 