### PR TITLE
Add helper function for running async coroutines under existing event loop

### DIFF
--- a/docs/notebooks/elmer_01_electrostatic.py
+++ b/docs/notebooks/elmer_01_electrostatic.py
@@ -111,7 +111,8 @@ help(run_capacitive_simulation_elmer)
 #    The meshing parameters and element order shown here are very lax. As such, the computed capacitances are not very accurate.
 # ```
 
-# %%
+# %% tags=["hide-output"]
+
 results = run_capacitive_simulation_elmer(
     c,
     layer_stack=layer_stack,
@@ -156,10 +157,10 @@ if results.field_file_location:
     pv.start_xvfb()
     pv.set_jupyter_backend("panel")
     field = pv.read(results.field_file_location)
-    slice = field.slice_orthogonal(z=layer_stack.layers["bw"].zmin * 1e-6)
+    field_slice = field.slice_orthogonal(z=layer_stack.layers["bw"].zmin * 1e-6)
 
     p = pv.Plotter()
-    p.add_mesh(slice, scalars="electric field", cmap="turbo")
+    p.add_mesh(field_slice, scalars="electric field", cmap="turbo")
     p.show_grid()
     p.camera_position = "xy"
     p.enable_parallel_projection()

--- a/gplugins/elmer/get_capacitance.py
+++ b/gplugins/elmer/get_capacitance.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import itertools
 import shutil
@@ -18,7 +17,7 @@ from jinja2 import Environment, FileSystemLoader
 from numpy import isfinite
 from pandas import read_csv
 
-from gplugins.async_utils import execute_and_stream_output
+from gplugins.async_utils import execute_and_stream_output, run_async_with_event_loop
 from gplugins.typings import ElectrostaticResults, RFMaterialSpec
 
 ELECTROSTATIC_SIF = "electrostatic.sif"
@@ -64,7 +63,7 @@ def _elmergrid(simulation_folder: Path, name: str, n_processes: int = 1):
         raise RuntimeError(
             "`ElmerGrid` not found. Make sure it is available in your PATH."
         )
-    asyncio.run(
+    run_async_with_event_loop(
         execute_and_stream_output(
             [elmergrid, "14", "2", name, "-autoclean"],
             shell=False,
@@ -74,7 +73,7 @@ def _elmergrid(simulation_folder: Path, name: str, n_processes: int = 1):
         )
     )
     if n_processes > 1:
-        asyncio.run(
+        run_async_with_event_loop(
             execute_and_stream_output(
                 [
                     elmergrid,
@@ -106,7 +105,7 @@ def _elmersolver(simulation_folder: Path, name: str, n_processes: int = 1):
             f"`{elmersolver_name}` not found. Make sure it is available in your PATH."
         )
     sif_file = str(simulation_folder / f"{Path(name).stem}.sif")
-    asyncio.run(
+    run_async_with_event_loop(
         execute_and_stream_output(
             [elmersolver, sif_file]
             if no_mpi

--- a/gplugins/palace/get_capacitance.py
+++ b/gplugins/palace/get_capacitance.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import itertools
 import json
@@ -18,7 +17,7 @@ from gdsfactory.technology import LayerStack
 from numpy import isfinite
 from pandas import read_csv
 
-from gplugins.async_utils import execute_and_stream_output
+from gplugins.async_utils import execute_and_stream_output, run_async_with_event_loop
 from gplugins.typings import ElectrostaticResults, RFMaterialSpec
 
 ELECTROSTATIC_JSON = "electrostatic.json"
@@ -105,7 +104,7 @@ def _palace(simulation_folder: Path, name: str, n_processes: int = 1):
         raise RuntimeError("palace not found. Make sure it is available in your PATH.")
 
     json_file = simulation_folder / f"{Path(name).stem}.json"
-    asyncio.run(
+    run_async_with_event_loop(
         execute_and_stream_output(
             [palace, json_file]
             if n_processes == 1


### PR DESCRIPTION
This PR adds a helper function called `run_async_with_event_loop` for running async coroutines in environments such as IPython using nest_async. This fixes #68 and the Elmer notebook output is suppressed to not get incredibly long logs.