### PR TITLE
include zmax option in z-mapping of layerstack

### DIFF
--- a/gplugins/gmsh/parse_layerstack.py
+++ b/gplugins/gmsh/parse_layerstack.py
@@ -53,9 +53,10 @@ def map_unique_layerstack_z(
     return unique_z_dict
 
 
-def get_layer_overlaps_z(layerstack: LayerStack,
-                         include_zmax: bool = True,
-                         ):
+def get_layer_overlaps_z(
+    layerstack: LayerStack,
+    include_zmax: bool = True,
+):
     """Maps layers to unique LayerStack z coordinates.
 
     Args:

--- a/gplugins/gmsh/parse_layerstack.py
+++ b/gplugins/gmsh/parse_layerstack.py
@@ -24,11 +24,13 @@ def list_unique_layerstack_z(
 
 def map_unique_layerstack_z(
     layerstack: LayerStack,
+    include_zmax: bool = True,
 ):
     """Map unique LayerStack z coordinates to various layers.
 
     Args:
         layerstack: LayerStack
+        include_zmax: if True, will map a layername to its zmax coordinate, otherwise not
     Returns:
         Dict with layernames as keys and set of unique z-values where the layer is present
     """
@@ -38,19 +40,22 @@ def map_unique_layerstack_z(
     for layername, layer in layer_dict.items():
         zmin = layer["zmin"]
         zmax = layer["zmin"] + layer["thickness"]
-        if zmax > zmin:
+        z_start, z_end = sorted([zmin, zmax])
+        if include_zmax:
             unique_z_dict[layername] = {
-                z for z in z_levels if (z >= zmin and z <= zmax)
+                z for z in z_levels if (z >= z_start and z <= z_end)
             }
         else:
             unique_z_dict[layername] = {
-                z for z in z_levels if (z >= zmax and z <= zmin)
+                z for z in z_levels if (z >= z_start and z < z_end)
             }
 
     return unique_z_dict
 
 
-def get_layer_overlaps_z(layerstack: LayerStack):
+def get_layer_overlaps_z(layerstack: LayerStack,
+                         include_zmax: bool = True,
+                         ):
     """Maps layers to unique LayerStack z coordinates.
 
     Args:
@@ -59,7 +64,7 @@ def get_layer_overlaps_z(layerstack: LayerStack):
         Dict with unique z-positions as keys, and list of layernames as entries
     """
     z_grid = list_unique_layerstack_z(layerstack)
-    unique_z_dict = map_unique_layerstack_z(layerstack)
+    unique_z_dict = map_unique_layerstack_z(layerstack, include_zmax)
     intersection_z_dict = {}
     for z in z_grid:
         current_layers = {


### PR DESCRIPTION
preserves default behaviour, but allows the z-level sorting to not map a layer to its zmax coordinate (useful when dealing with ranges instead of the levels themselves)