### PR TITLE
Experimental Palace plugin for full-wave S-parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ gdsfactory plugins:
 - `meep` for FDTD.
 - `mpb` for MPB mode solver.
 - `elmer` for electrostatic (capacitive) simulations.
-- `palace` for electrostatic (capacitive) simulations.
+- `palace` for full-wave driven (S parameter) and electrostatic (capacitive) simulations.
 - `web` for gdsfactory webapp.
 - `vlsir` for parsing GDS-extracted circuit netlists into Spice, Spectre and Xyce Schematic File formats.
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -24,6 +24,7 @@ parts:
           - file: notebooks/tcad_03_numerical_implantation
           - file: notebooks/elmer_01_electrostatic
           - file: notebooks/palace_01_electrostatic
+          - file: notebooks/palace_02_fullwave
       - file: plugins_mode_solver
         sections:
           - file: notebooks/femwell_01_modes

--- a/docs/api_design.rst
+++ b/docs/api_design.rst
@@ -218,3 +218,16 @@ Electrostatics
    :toctree: _autosummary/
 
    run_capacitive_simulation_palace
+
+************
+Full-wave RF
+************
+
+.. currentmodule:: gplugins.palace
+
+.. rubric:: Palace
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   run_scattering_simulation_palace

--- a/docs/notebooks/palace_02_fullwave.py
+++ b/docs/notebooks/palace_02_fullwave.py
@@ -1,0 +1,238 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.0
+#   kernelspec:
+#     display_name: base
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Full-wave driven simulations with Palace
+#
+# ```{warning}
+# The full-wave driven plugin for Palace is experimental and currently supports only lumped ports that have to be placed manually as rectangles in the geometry.
+# ```
+#
+# Here, we show how Palace may be used to perform full-wave driven simulations in the frequency domain.
+# See [Palace – Crosstalk Between Coplanar Waveguides](https://awslabs.github.io/palace/stable/examples/cpw/) for more details.
+#
+# For a given geometry, one needs to specify the terminals where to apply an excitation similar to Ansys HFSS.
+# To this end, lumped ports (or wave ports) have to be added to the geometry to simulate.
+# This effectively solves the scattering parameters for the terminals.
+#
+# In this notebook, we the same interdigital capacitor as in {doc}`palace_01_electrostatic.py` but add lumped ports to the geometry.
+# Afterwards, the capacitance matrix can be computed from the scattering parameters as described in {eq}`s_to_y_to_c`.
+#
+# ## Installation
+# See [Palace – Installation](https://awslabs.github.io/palace/stable/install/) for installation or compilation instructions. Gplugins assumes `palace` is available in your PATH environment variable.
+#
+# Alternatively, [Singularity / Apptainer](https://apptainer.org/) containers may be used. Instructions for building and an example definition file are found at [Palace – Build using Singularity/Apptainer](https://awslabs.github.io/palace/dev/install/#Build-using-Singularity/Apptainer).
+# Afterwards, an easy install method is to add a script to `~/.local/bin` (or elsewhere in `PATH`) calling the Singularity container. For example, one may create a `palace` file containing
+# ```console
+# #!/bin/bash
+# singularity exec ~/palace.sif /opt/palace/bin/palace "$@"
+# ```
+#
+# ## Geometry, layer config and materials
+
+# %%
+
+import os
+from math import inf
+from pathlib import Path
+
+import gdsfactory as gf
+import numpy as np
+import pyvista as pv
+import skrf
+from gdsfactory.components.interdigital_capacitor_enclosed import (
+    interdigital_capacitor_enclosed,
+)
+from gdsfactory.generic_tech import LAYER, get_generic_pdk
+from gdsfactory.technology import LayerStack
+from gdsfactory.technology.layer_stack import LayerLevel
+from IPython.display import display
+from matplotlib import pyplot as plt
+
+from gplugins.palace import run_scattering_simulation_palace
+from gplugins.typings import RFMaterialSpec
+
+gf.config.rich_output()
+PDK = get_generic_pdk()
+PDK.activate()
+
+# %% [markdown]
+# We employ an example LayerStack used in superconducting circuits similar to {cite:p}`marxer_long-distance_2023`.
+
+# %%
+layer_stack = LayerStack(
+    layers=dict(
+        substrate=LayerLevel(
+            layer=LAYER.WAFER,
+            thickness=500,
+            zmin=0,
+            material="Si",
+            mesh_order=99,
+        ),
+        bw=LayerLevel(
+            layer=LAYER.WG,
+            thickness=200e-3,
+            zmin=500,
+            material="Nb",
+            mesh_order=2,
+        ),
+        bw_port=LayerLevel(
+            layer=LAYER.PORT,
+            thickness=200e-3,
+            zmin=500,
+            material="Nb",
+            mesh_order=2,
+        ),
+    )
+)
+material_spec: RFMaterialSpec = {
+    "Si": {"relative_permittivity": 11.45, "relative_permeability": 1},
+    "Nb": {"relative_permittivity": inf, "relative_permeability": 1},
+    "vacuum": {"relative_permittivity": 1, "relative_permeability": 1},
+}
+
+# %%
+simulation_box = [[-200, -200], [200, 200]]
+c = gf.Component("scattering_palace")
+cap = c << interdigital_capacitor_enclosed(
+    metal_layer=LAYER.WG, gap_layer=LAYER.DEEPTRENCH, enclosure_box=simulation_box
+)
+c.show()
+
+# %%
+
+# Add lumped port rectangles manually, see examples for https://awslabs.github.io/palace/stable/examples/cpw/
+lumped_port_1_1 = gf.components.bbox(((-40, 11), (-46, 5)), layer=LAYER.PORT)
+lumped_port_1_2 = gf.components.bbox(((-40, -11), (-46, -5)), layer=LAYER.PORT)
+c << lumped_port_1_1
+c << lumped_port_1_2
+c.add_port("o1_1", lumped_port_1_1.center, layer=LAYER.PORT, width=1)
+c.add_port("o1_2", lumped_port_1_2.center, layer=LAYER.PORT, width=1)
+
+lumped_port_2_1 = gf.components.bbox(((40, 11), (46, 5)), layer=LAYER.PORT)
+lumped_port_2_2 = gf.components.bbox(((40, -11), (46, -5)), layer=LAYER.PORT)
+c << lumped_port_2_1
+c << lumped_port_2_2
+c.add_port("o2_1", lumped_port_2_1.center, layer=LAYER.PORT, width=1)
+c.add_port("o2_2", lumped_port_2_2.center, layer=LAYER.PORT, width=1)
+
+substrate = gf.components.bbox(bbox=simulation_box, layer=LAYER.WAFER)
+c << substrate
+c.flatten()
+c.show()
+
+# %% [markdown]
+# ## Running the simulation
+# ```{eval-rst}
+# We use the function :func:`~run_scattering_simulation_palace`. This runs the simulation and returns an instance of :class:`~DrivenFullWaveResults` containing the capacitance matrix and a path to the mesh and the field solutions.
+# ```
+
+# %%
+help(run_scattering_simulation_palace)
+
+# %%
+results = run_scattering_simulation_palace(
+    c,
+    layer_stack=layer_stack,
+    material_spec=material_spec,
+    only_one_port=True,
+    simulation_folder=Path(os.getcwd()) / "temporary",
+    driven_settings={
+        "MinFreq": 0.1,
+        "MaxFreq": 5,
+        "FreqStep": 5,
+    },
+    mesh_parameters=dict(
+        background_tag="vacuum",
+        background_padding=(0,) * 5 + (700,),
+        portnames=c.ports,
+        verbosity=1,
+        default_characteristic_length=200,
+        layer_portname_delimiter=(delimiter := "__"),
+        resolutions={
+            "bw": {
+                "resolution": 14,
+            },
+            "substrate": {
+                "resolution": 50,
+            },
+            "vacuum": {
+                "resolution": 120,
+            },
+            **{
+                f"bw_port{delimiter}{port}_vacuum": {
+                    "resolution": 8,
+                    "DistMax": 30,
+                    "DistMin": 10,
+                    "SizeMax": 14,
+                    "SizeMin": 3,
+                }
+                for port in c.ports
+            },
+        },
+    ),
+)
+display(results)
+
+
+# %% [markdown]
+#
+# The capacitance matrix can be solved from the admittance matrix $Y$ as
+#
+# ```{math}
+# :label: s_to_y_to_c
+#     C_{\text{i,j}} = \frac{\mathrm{Im}\,Y_{\text{i,j}}}{\mathrm{i} \omega}
+#     .
+# ```
+
+# %%
+df = results.scattering_matrix
+df.columns = df.columns.str.strip()
+s_complex = 10 ** df["|S[2][1]| (dB)"].values * np.exp(
+    1j * skrf.degree_2_radian(df["arg(S[2][1]) (deg.)"].values)
+)
+ntw = skrf.Network(f=df["f (GHz)"].values, s=s_complex, z0=50)
+cap = np.imag(ntw.y.flatten()) / (ntw.f * 2 * np.pi)
+display(cap)
+
+plt.plot(ntw.f, cap * 1e15)
+plt.xlabel("Freq (GHz)")
+plt.ylabel("C (fF)")
+
+# %% [markdown]
+# <div class="alert alert-success">
+# TODO the results don't seem good, something must be wrong in the setup…
+# </div>
+
+# %%
+if results.field_file_locations:
+    pv.start_xvfb()
+    pv.set_jupyter_backend("panel")
+    field = pv.read(results.field_file_locations[0])
+    slice = field.slice_orthogonal(z=layer_stack.layers["bw"].zmin * 1e-6)
+
+    p = pv.Plotter()
+    p.add_mesh(slice, scalars="Ue", cmap="turbo")
+    p.show_grid()
+    p.camera_position = "xy"
+    p.enable_parallel_projection()
+    p.show()
+
+# %% [markdown]
+# ## Bibliography
+# ```{bibliography}
+# :style: unsrt
+# ```

--- a/gplugins/palace/__init__.py
+++ b/gplugins/palace/__init__.py
@@ -1,5 +1,7 @@
 from gplugins.palace.get_capacitance import run_capacitive_simulation_palace
+from gplugins.palace.get_scattering import run_scattering_simulation_palace
 
 __all__ = [
     "run_capacitive_simulation_palace",
+    "run_scattering_simulation_palace",
 ]

--- a/gplugins/palace/driven.json
+++ b/gplugins/palace/driven.json
@@ -1,0 +1,66 @@
+{
+  "Problem":
+  {
+    "Type": "Driven",
+    "Verbose": 3,
+    "Output": "postpro"
+  },
+  "Model":
+  {
+    "Mesh": "#MESH",
+    "L0": 1.0e-6,
+    "Refinement":
+    {
+      "UniformLevels": 1
+    }
+  },
+  "Domains":
+  {
+    "Materials":
+    [
+      {
+        "Attributes": [2],
+        "Permeability": 1.0,
+        "Permittivity": 1.0,
+        "LossTan": 0.0
+      },
+      {
+        "Attributes": [1],
+        "Permeability": [0.99999975, 0.99999975, 0.99999979],
+        "Permittivity": [9.3, 9.3, 11.5],
+        "LossTan": [3.0e-5, 3.0e-5, 8.6e-5],
+        "MaterialAxes": [[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]]
+      }
+    ],
+    "Postprocessing":
+    {}
+  },
+  "Boundaries":
+  {
+    "PEC":
+    {},
+    "Absorbing":
+    {},
+    "Postprocessing":
+    {}
+  },
+  "Solver":
+  {
+    "Order": 1,
+    "Driven":
+    {
+      "MinFreq": 1.0,
+      "MaxFreq": 10.0,
+      "FreqStep": 0.1,
+      "SaveStep": 40,
+      "AdaptiveTol": 1.0e-3
+    },
+    "Linear":
+    {
+      "Type": "Default",
+      "KSPType": "GMRES",
+      "Tol": 1.0e-8,
+      "MaxIts": 100
+    }
+  }
+}

--- a/gplugins/palace/get_scattering.py
+++ b/gplugins/palace/get_scattering.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import inspect
+import itertools
+import json
+import re
+import shutil
+import subprocess
+from collections.abc import Collection, Mapping, Sequence
+from math import atan2, degrees, inf
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import gdsfactory as gf
+import gmsh
+import pandas as pd
+from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.technology import LayerStack
+from numpy import isfinite
+
+from gplugins.typings import DrivenFullWaveResults, RFMaterialSpec
+
+DRIVE_JSON = "driven.json"
+DRIVEN_TEMPLATE = Path(__file__).parent / DRIVE_JSON
+
+
+def _generate_json(
+    simulation_folder: Path,
+    name: str,
+    bodies: dict[str, dict[str, Any]],
+    absorbing_surfaces: Collection[str],
+    layer_stack: LayerStack,
+    material_spec: RFMaterialSpec,
+    element_order: int,
+    physical_name_to_dimtag_map: dict[str, tuple[int, int]],
+    metal_surfaces: Collection[str],
+    background_tag: str | None = None,
+    edge_signals: Sequence[Sequence[str]] | None = None,
+    internal_signals: Sequence[tuple[Sequence[str], Sequence[str]]] | None = None,
+    internal_signal_directions: Mapping[tuple[str, str], str] | None = None,
+    simulator_params: Mapping[str, Any] | None = None,
+    driven_settings: Mapping[str, float | int | bool] | None = None,
+    mesh_refinement_levels: int | None = None,
+    only_one_port: bool | None = True,
+) -> list[Path]:
+    """Generates a json file for full-wave Palace simulations."""
+    # TODO: Generalise to merger with the Elmer implementations"""
+    used_materials = {v.material for v in layer_stack.layers.values()} | (
+        {background_tag} if background_tag else {}
+    )
+    used_materials = {
+        k: material_spec[k]
+        for k in used_materials
+        if isfinite(material_spec[k].get("relative_permittivity", inf))
+    }
+
+    with open(DRIVEN_TEMPLATE) as fp:
+        palace_json_data = json.load(fp)
+
+    material_to_attributes_map = dict()
+    for k, v in bodies.items():
+        material_to_attributes_map[v["material"]] = material_to_attributes_map.get(
+            v["material"], []
+        ) + [physical_name_to_dimtag_map[k][1]]
+
+    palace_json_data["Model"]["Mesh"] = f"{name}.msh"
+    if mesh_refinement_levels:
+        palace_json_data["Model"]["Refinement"] = {}
+        palace_json_data["Model"]["Refinement"][
+            "UniformLevels"
+        ] = mesh_refinement_levels
+    palace_json_data["Domains"]["Materials"] = [
+        {
+            "Attributes": material_to_attributes_map.get(material, None),
+            "Permittivity": float(props["relative_permittivity"]),
+            "Permeability": float(props["relative_permeability"]),
+            "LossTan": float(props.get("loss_tangent", 0.0)),
+            "Conductivity": float(props.get("conductivity", 0.0)),
+        }
+        for material, props in used_materials.items()
+    ]
+    # TODO list here attributes that contained LossTAN
+    # palace_json_data["Domains"]["Postprocessing"]["Dielectric"] = [
+    # ]
+
+    palace_json_data["Boundaries"]["PEC"] = {
+        "Attributes": [
+            physical_name_to_dimtag_map[layer][1]
+            for layer in set(metal_surfaces)
+            - set(itertools.chain.from_iterable(edge_signals or []))
+            - set(
+                itertools.chain.from_iterable(
+                    itertools.chain.from_iterable(internal_signals or [])
+                )
+            )
+            - set(absorbing_surfaces or [])
+        ]
+    }
+
+    # Farfield surface
+    palace_json_data["Boundaries"]["Absorbing"] = {
+        "Attributes": [
+            physical_name_to_dimtag_map[e][1] for e in absorbing_surfaces
+        ],  # TODO get farfield _None etc
+        "Order": 1,
+    }
+    # TODO palace_json_data["Boundaries"]["Postprocessing"]["Dielectric"]
+
+    palace_json_data["Solver"]["Order"] = element_order
+    if driven_settings is not None:
+        palace_json_data["Solver"]["Driven"] |= driven_settings
+    if simulator_params is not None:
+        palace_json_data["Solver"]["Linear"] |= simulator_params
+
+    # need one simulation per port to excite, see https://github.com/awslabs/palace/issues/81
+    jsons = []
+    for port in itertools.chain(edge_signals or [], internal_signals or []):
+        port_i = 0
+        # TODO regex here is hardly robust
+        port_name = re.search(
+            r"__(.*?)___", port[0][0] if isinstance(port, tuple) else port[0]
+        ).group(1)
+        if edge_signals:
+            palace_json_data["Boundaries"]["WavePort"] = [
+                {
+                    "Index": (port_i := port_i + 1),
+                    "Attributes": [
+                        physical_name_to_dimtag_map[signal][1]
+                        for signal in signal_group
+                    ],
+                    "Excitation": port == signal_group,
+                    "Mode": 1,
+                    "Offset": 0.0,
+                }
+                for signal_group in edge_signals
+            ]
+        # TODO only two pair lumped ports supported for now
+        if internal_signals:
+            palace_json_data["Boundaries"]["LumpedPort"] = [
+                {
+                    "Index": (port_i := port_i + 1),
+                    "Elements": [
+                        {
+                            "Attributes": [
+                                physical_name_to_dimtag_map[signal][1]
+                                for signal in signal_group_1
+                            ],
+                            "Direction": internal_signal_directions[
+                                re.search(r"__(.*?)___", signal_group_1[0]).group(1)
+                            ],
+                        },
+                        {
+                            "Attributes": [
+                                physical_name_to_dimtag_map[signal][1]
+                                for signal in signal_group_2
+                            ],
+                            "Direction": internal_signal_directions[
+                                re.search(r"__(.*?)___", signal_group_2[0]).group(1)
+                            ],
+                        },
+                    ],
+                    "Excitation": port == (signal_group_1, signal_group_2),
+                    "R": 50,
+                }
+                for (signal_group_1, signal_group_2) in internal_signals
+            ]
+        palace_json_data["Problem"]["Output"] = f"postpro_{port_name}"
+
+        with open(
+            (json_name := simulation_folder / f"{name}_{port_name}.json"),
+            "w",
+            encoding="utf-8",
+        ) as fp:
+            json.dump(palace_json_data, fp, indent=4)
+        jsons.append(json_name)
+
+        # TODO if a user has both wave ports and lumped ports, this currently allows only computing from waveport elsewhere
+        if only_one_port:
+            break
+
+    return jsons
+
+
+def _palace(
+    simulation_folder: Path, json_files: Collection[Path | str], n_processes: int = 1
+):
+    """Run simulations with Palace."""
+
+    # split processes as evenly as possible
+    quotient, remainder = divmod(n_processes, len(json_files))
+    n_processes_per_json = [quotient] * len(json_files)
+    for i in range(remainder):
+        n_processes_per_json[i] = max(
+            n_processes_per_json[i] + 1, 1
+        )  # need at least one
+
+    palace = shutil.which("palace")
+    if palace is None:
+        raise RuntimeError("palace not found. Make sure it is available in your PATH.")
+    # TODO handle better than this. Ideally distributed and scheduled with @ray.remote
+    for json_file, n_processes_json in zip(json_files, n_processes_per_json):
+        with open(str(json_file) + "_palace.log", "w", encoding="utf-8") as fp:
+            # TODO raise error on actual failure
+            p = subprocess.Popen(
+                [palace, str(json_file)]
+                if n_processes == 1
+                else [palace, "-np", str(n_processes_json), str(json_file)],
+                cwd=simulation_folder,
+                stdout=fp,
+                stderr=fp,
+            )
+    p.communicate()  # wait only for the last iteration
+
+
+def _read_palace_results(
+    simulation_folder: Path,
+    mesh_filename: str,
+    ports: Collection[str],
+    is_temporary: bool,
+) -> DrivenFullWaveResults:
+    """Fetch results from successful Palace simulations."""
+    scattering_matrix = pd.DataFrame()
+    for port in ports:
+        scattering_matrix = pd.concat(
+            [
+                scattering_matrix,
+                pd.read_csv(
+                    simulation_folder / f"postpro_{port}" / "port-S.csv", dtype=float
+                ),
+            ],
+            axis="columns",
+        )
+    scattering_matrix = (
+        scattering_matrix.T.drop_duplicates().T
+    )  # Remove duplicate freqs.
+    scattering_matrix.columns = scattering_matrix.columns.str.strip()
+    DrivenFullWaveResults.update_forward_refs()
+    return DrivenFullWaveResults(
+        scattering_matrix=scattering_matrix,  # TODO maybe convert to SDict or similar from DataFrame
+        **(
+            {}
+            if is_temporary
+            else dict(
+                mesh_location=simulation_folder / mesh_filename,
+                field_file_locations=[
+                    simulation_folder
+                    / f"postpro_{port}"
+                    / "paraview"
+                    / "driven"
+                    / "driven.pvd"
+                    for port in ports
+                ],
+            )
+        ),
+    )
+
+
+def run_scattering_simulation_palace(
+    component: gf.Component,
+    element_order: int = 1,
+    n_processes: int = 1,
+    layer_stack: LayerStack | None = None,
+    material_spec: RFMaterialSpec | None = None,
+    simulation_folder: Path | str | None = None,
+    simulator_params: Mapping[str, Any] | None = None,
+    driven_settings: Mapping[str, float | int | bool] | None = None,
+    mesh_refinement_levels: int | None = None,
+    only_one_port: bool | None = True,
+    mesh_parameters: dict[str, Any] | None = None,
+    mesh_file: Path | str | None = None,
+) -> DrivenFullWaveResults:
+    """Run full-wave finite element method simulations using
+    `Palace`_.
+    Returns the field solution and resulting scattering matrix.
+
+    .. note:: You should have `palace` in your PATH.
+
+    Args:
+        component: Simulation environment as a gdsfactory component.
+        element_order:
+            Order of polynomial basis functions.
+            Higher is more accurate but takes more memory and time to run.
+        n_processes: Number of processes to use for parallelization
+        layer_stack:
+            :class:`~LayerStack` defining defining what layers to include in the simulation
+            and the material properties and thicknesses.
+        material_spec:
+            :class:`~RFMaterialSpec` defining material parameters for the ones used in ``layer_stack``.
+        simulation_folder:
+            Directory for storing the simulation results.
+            Default is a temporary directory.
+        simulator_params: Palace-specific parameters. This will be expanded to ``solver["Linear"]`` in
+            the Palace config, see `Palace documentation <https://awslabs.github.io/palace/stable/config/solver/#solver[%22Linear%22]>`_
+        driven_settings: Driven full-wave parameters in Palace. This will be expanded to ``solver["Driven"]`` in
+            the Palace config, see `Palace documentation <https://awslabs.github.io/palace/stable/config/solver/#solver[%22Driven%22]>`_
+        mesh_refinement_levels: Refine mesh this many times, see Palace for details.
+        only_one_port: Whether to solve only scattering from the first port to other ports, e.g., `S11, S12, S13, ...`
+        mesh_parameters:
+            Keyword arguments to provide to :func:`~Component.to_gmsh`.
+        mesh_file: Path to a ready mesh to use. Useful for reusing one mesh file.
+            By default a mesh is generated according to ``mesh_parameters``.
+
+    .. _Palace https://github.com/awslabs/palace
+    """
+
+    if layer_stack is None:
+        layer_stack = LayerStack(
+            layers={
+                k: LAYER_STACK.layers[k]
+                for k in (
+                    "core",
+                    "substrate",
+                    "box",
+                )
+            }
+        )
+    if material_spec is None:
+        material_spec: RFMaterialSpec = {
+            "si": {"relative_permittivity": 11.45},
+            "sio2": {"relative_permittivity": 1},
+            "vacuum": {"relative_permittivity": 1},
+        }
+
+    temp_dir = TemporaryDirectory()
+    simulation_folder = Path(simulation_folder or temp_dir.name)
+    simulation_folder.mkdir(exist_ok=True, parents=True)
+
+    filename = component.name + ".msh"
+    if mesh_file:
+        shutil.copyfile(str(mesh_file), str(simulation_folder / filename))
+    else:
+        component.to_gmsh(
+            type="3D",
+            filename=simulation_folder / filename,
+            layer_stack=layer_stack,
+            gmsh_version=2.2,  # see https://mfem.org/mesh-formats/#gmsh-mesh-formats
+            **(mesh_parameters or {}),
+        )
+
+    # re-read the mesh
+    # `interruptible` works on gmsh versions >= 4.11.2
+    gmsh.initialize(
+        **(
+            {"interruptible": False}
+            if "interruptible" in inspect.getfullargspec(gmsh.initialize).args
+            else {}
+        )
+    )
+    gmsh.option.setNumber("Mesh.MshFileVersion", 2.2)
+    gmsh.merge(str(simulation_folder / filename))
+    mesh_surface_entities = {
+        gmsh.model.getPhysicalName(*dimtag)
+        for dimtag in gmsh.model.getPhysicalGroups(dim=2)
+    }
+    background_tag = (mesh_parameters or {}).get("background_tag", "vacuum")
+
+    # Signals are converted to Boundaries
+    # TODO currently assumes signal layers have `bw`
+
+    ground_layers = {
+        next(k for k, v in layer_stack.layers.items() if v.layer == port.layer)
+        for port in component.get_ports()
+    } | {layer for layer in component.get_layer_names() if "_bw" in layer}
+    # TODO infer port delimiter from somewhere
+    port_delimiter = "__"
+    metal_surfaces = [
+        e for e in mesh_surface_entities if any(ground in e for ground in ground_layers)
+    ]
+    # Group signal BCs by ports and lumped port pairs
+    # TODO tuple pairs by o1_1 o1_2
+
+    lumped_two_ports = [
+        e for e in [port.split("_") for port in component.ports] if len(e) > 1
+    ]
+    lumped_two_port_pairs = [
+        ("_".join(p1), "_".join(p2))
+        for p1, p2 in itertools.combinations(lumped_two_ports, 2)
+        if p1[0] == p2[0]
+    ]
+    metal_signal_surfaces_grouped = [
+        [e for e in metal_surfaces if port in e and background_tag in e]
+        for port in component.ports
+    ]
+    metal_signal_surfaces_paired = [
+        tuple(
+            e
+            for e in metal_signal_surfaces_grouped
+            if all(p1 in s or p2 in s for s in e)
+        )
+        for p1, p2 in lumped_two_port_pairs
+    ]
+
+    metal_ground_surfaces = set(metal_surfaces) - set(
+        itertools.chain.from_iterable(metal_signal_surfaces_grouped)
+    )
+
+    ground_layers |= metal_ground_surfaces
+
+    def _xy_plusminus_direction(point_1, point_2):
+        # TODO update after https://github.com/awslabs/palace/pull/75 is merged
+        delta_x = point_2[0] - point_1[0]
+        delta_y = point_2[1] - point_1[1]
+        angle = atan2(delta_y, delta_x)
+        angle_deg = degrees(angle) + 360
+
+        directions = ["+X", "+Y", "-X", "-Y"]
+        index = round(angle_deg / 90) % 4  # TODO check if shift is correct
+
+        return directions[index]
+
+    lumped_two_port_directions = {
+        ports[0]: _xy_plusminus_direction(
+            *[component.get_ports_dict()[port].center for port in ports]
+        )
+        for ports in itertools.chain(
+            lumped_two_port_pairs, [tuple(reversed(e)) for e in lumped_two_port_pairs]
+        )
+    }
+
+    # dielectrics
+    bodies = {
+        k: {
+            "material": v.material,
+        }
+        for k, v in layer_stack.layers.items()
+        if port_delimiter not in k and k not in ground_layers
+    }
+    if background_tag:
+        bodies = {**bodies, background_tag: {"material": background_tag}}
+
+    # TODO refactor to not require this map, the same information could be transferred with the variables above
+    physical_name_to_dimtag_map = {
+        gmsh.model.getPhysicalName(*dimtag): dimtag
+        for dimtag in gmsh.model.getPhysicalGroups()
+    }
+    absorbing_surfaces = {
+        k
+        for k in physical_name_to_dimtag_map.keys()
+        if "___None" in k
+        and background_tag in k
+        and not any(p in k for p in component.ports)
+    } - set(
+        ground_layers
+    )  # keep metal edge as PEC
+
+    gmsh.finalize()
+
+    jsons = _generate_json(
+        simulation_folder,
+        component.name,
+        bodies,
+        absorbing_surfaces,
+        layer_stack,
+        material_spec,
+        element_order,
+        physical_name_to_dimtag_map,
+        metal_surfaces,
+        background_tag,
+        None,  # TODO edge
+        metal_signal_surfaces_paired,  # internal
+        lumped_two_port_directions,
+        simulator_params,
+        driven_settings,
+        mesh_refinement_levels,
+        only_one_port,
+    )
+    _palace(simulation_folder, jsons, n_processes)
+    results = _read_palace_results(
+        simulation_folder,
+        filename,
+        [e[0] for e in lumped_two_port_pairs][0 : (1 if only_one_port else -1)],
+        is_temporary=str(simulation_folder) == temp_dir.name,
+    )
+    temp_dir.cleanup()
+    return results

--- a/gplugins/typings.py
+++ b/gplugins/typings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-import pathlib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -12,8 +14,8 @@ class ElectrostaticResults(BaseModel):
     """Results class for electrostatic simulations."""
 
     capacitance_matrix: CDict
-    mesh_location: pathlib.Path | None = None
-    field_file_location: pathlib.Path | None = None
+    mesh_location: Path | None = None
+    field_file_location: Path | None = None
 
     # TODO uncomment after move to pydantic v2
     # @computed_field
@@ -35,8 +37,17 @@ class ElectrostaticResults(BaseModel):
     #     return matrix
 
 
+class DrivenFullWaveResults(BaseModel):
+    """Results class for driven full-wave simulations."""
+
+    scattering_matrix: Any  # TODO convert to SDict or similar
+    mesh_location: Path | None = None
+    field_file_locations: Sequence[Path] | None = None
+
+
 __all__ = (
     "CDict",
-    "RFMaterialSpec",
+    "DrivenFullWaveResults",
     "ElectrostaticResults",
+    "RFMaterialSpec",
 )

--- a/gplugins/utils/get_scattering.py
+++ b/gplugins/utils/get_scattering.py
@@ -1,0 +1,76 @@
+from collections.abc import Mapping
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import gdsfactory as gf
+from gdsfactory.pdk import get_sparameters_path
+from gdsfactory.typings import ComponentSpec
+
+from gplugins.palace.get_scattering import run_scattering_simulation_palace
+from gplugins.typings import (
+    DrivenFullWaveResults,
+)
+
+
+def get_scattering(
+    component: ComponentSpec,
+    simulator: str = "palace",
+    simulator_params: Mapping[str, Any] | None = None,
+    simulation_folder: Path | str | None = None,
+    **kwargs,
+) -> DrivenFullWaveResults:
+    """Simulate component with a full-wave simulation and return scattering matrix.
+
+    Args:
+        component: component or component factory.
+        simulator: Simulator to use. The choices are 'elmer' or 'palace'. Both require manual install.
+            This changes the format of ``simulator_params``.
+        simulator_params: Simulator-specific params as a dictionary. See template files for more details.
+            Has reasonable defaults.
+        simulation_folder: Directory for storing the simulation results. Default is a temporary directory.
+        **kwargs: Simulation settings propagated to inner :func:`~run_capacitive_simulation_elmer` or
+            :func:`~run_capacitive_simulation_palace` implementation.
+    """
+    simulation_folder = Path(simulation_folder or get_sparameters_path())
+    component = gf.get_component(component)
+
+    simulation_folder = (
+        simulation_folder / component.function_name
+        if hasattr(component, "function_name")
+        else simulation_folder
+    )
+    simulation_folder.mkdir(exist_ok=True, parents=True)
+
+    match simulator:
+        case "elmer":
+            raise NotImplementedError("TODO")
+        #     return run_scattering_simulation_elmer(
+        #         component,
+        #         simulation_folder=simulation_folder,
+        #         simulator_params=simulator_params,
+        #         **kwargs,
+        #     )
+        case "palace":
+            return run_scattering_simulation_palace(
+                component,
+                simulation_folder=simulation_folder,
+                simulator_params=simulator_params,
+                **kwargs,
+            )
+        case _:
+            raise UserWarning(f"{simulator=!r} not implemented!")
+
+    # TODO do we need to infer path or be explicit?
+    # component_hash = get_component_hash(component)
+    # kwargs_hash = get_kwargs_hash(**kwargs)
+    # simulation_hash = hashlib.md5((component_hash + kwargs_hash).encode()).hexdigest()
+
+    # return dirpath / f"{component.name}_{simulation_hash}.npz"
+
+
+get_scattering_elmer = partial(get_scattering, tool="elmer")
+get_scattering_palace = partial(get_scattering, tool="palace")
+
+# if __name__ == "__main__":
+# TODO example


### PR DESCRIPTION
This PR adds an experimental plugin for Palace that runs driven full-wave frequency-domain FEM and solves the S-parameters.

I consider it experimental as it currently only supports lumped ports, and the results using those seem inaccurate. Nevertheless, simulations can be run with nice field plots as results. 

We add:
* Example in docs
* Tests

but neither are run in CI, this is deferred to https://github.com/gdsfactory/gplugins/issues/64.