### PR TITLE
Improve RF simulation docs formatting slightly

### DIFF
--- a/docs/notebooks/elmer_01_electrostatic.py
+++ b/docs/notebooks/elmer_01_electrostatic.py
@@ -36,7 +36,6 @@
 # ## Geometry, layer config and materials
 
 # %% tags=["hide-input"]
-
 import os
 from math import inf
 from pathlib import Path
@@ -112,7 +111,6 @@ help(run_capacitive_simulation_elmer)
 # ```
 
 # %% tags=["hide-output"]
-
 results = run_capacitive_simulation_elmer(
     c,
     layer_stack=layer_stack,

--- a/docs/notebooks/palace_01_electrostatic.py
+++ b/docs/notebooks/palace_01_electrostatic.py
@@ -33,7 +33,6 @@
 # ## Geometry, layer config and materials
 
 # %% tags=["hide-input"]
-
 import os
 from math import inf
 from pathlib import Path
@@ -109,7 +108,7 @@ help(run_capacitive_simulation_palace)
 #    The meshing parameters and element order shown here are very lax. As such, the computed capacitances are not very accurate.
 # ```
 
-# %%
+# %% tags=["hide-output"]
 results = run_capacitive_simulation_palace(
     c,
     layer_stack=layer_stack,

--- a/docs/notebooks/palace_02_fullwave.py
+++ b/docs/notebooks/palace_02_fullwave.py
@@ -29,7 +29,7 @@
 # This effectively solves the scattering parameters for the terminals.
 #
 # In this notebook, we the same interdigital capacitor as in {doc}`palace_01_electrostatic.py` but add lumped ports to the geometry.
-# Afterwards, the capacitance matrix can be computed from the scattering parameters as described in {eq}`s_to_y_to_c`.
+# Afterwards, the capacitance matrix can be computed from the scattering parameters as described in Eq. {eq}`s_to_y_to_c`.
 #
 # ## Installation
 # See [Palace – Installation](https://awslabs.github.io/palace/stable/install/) for installation or compilation instructions. Gplugins assumes `palace` is available in your PATH environment variable.
@@ -43,8 +43,7 @@
 #
 # ## Geometry, layer config and materials
 
-# %%
-
+# %% tags=["hide-input"]
 import os
 from math import inf
 from pathlib import Path
@@ -113,7 +112,6 @@ cap = c << interdigital_capacitor_enclosed(
 c.show()
 
 # %%
-
 # Add lumped port rectangles manually, see examples for https://awslabs.github.io/palace/stable/examples/cpw/
 lumped_port_1_1 = gf.components.bbox(((-40, 11), (-46, 5)), layer=LAYER.PORT)
 lumped_port_1_2 = gf.components.bbox(((-40, -11), (-46, -5)), layer=LAYER.PORT)
@@ -143,7 +141,7 @@ c.show()
 # %%
 help(run_scattering_simulation_palace)
 
-# %%
+# %% tags=["hide-output"]
 results = run_scattering_simulation_palace(
     c,
     layer_stack=layer_stack,


### PR DESCRIPTION
This PR improves formatting in RF simulation docs slightly:
* add a hide-input tag to the imports in Palace scattering example
* add a hide-output tag to Palace simulations (though not yet run in CI, #64)
* remove empty lines before code to run