### PR TITLE
Show only locally cited references for Palace scattering docs

### DIFF
--- a/docs/notebooks/palace_02_fullwave.py
+++ b/docs/notebooks/palace_02_fullwave.py
@@ -233,4 +233,5 @@ if results.field_file_locations:
 # ## Bibliography
 # ```{bibliography}
 # :style: unsrt
+# :filter: docname in docnames
 # ```


### PR DESCRIPTION
I noticed the bibliography for Palace scattering includes all references in the bib file as opposed to only cited ones. This is fixed in the PR (and already correctly in the capacitance examples).

![image](https://github.com/gdsfactory/gplugins/assets/7860886/2fd97b11-1157-45ba-97c8-8da2e4283ec6)
