### PR TITLE
layernames to physical labels dict

### DIFF
--- a/gplugins/gmsh/define_polysurfaces.py
+++ b/gplugins/gmsh/define_polysurfaces.py
@@ -8,6 +8,7 @@ from shapely.affinity import scale
 def define_polysurfaces(
     polygons_dict: dict,
     layer_stack: LayerStack,
+    layer_physical_map: dict,
     model: Any,
     resolutions: dict,
     scale_factor: float = 1,
@@ -32,7 +33,9 @@ def define_polysurfaces(
                 model=model,
                 resolution=resolutions.get(layername, None),
                 mesh_order=layer_stack.layers.get(layername).mesh_order,
-                physical_name=layername,
+                physical_name=layer_physical_map[layername]
+                if layername in layer_physical_map
+                else layername,
             )
         )
 

--- a/gplugins/gmsh/get_mesh.py
+++ b/gplugins/gmsh/get_mesh.py
@@ -23,6 +23,7 @@ def get_mesh(
     type: str,
     layer_stack: LayerStack,
     layer_physical_map: dict | None = None,
+    layer_meshbool_map: dict | None = None,
     z: float | None = None,
     xsection_bounds=None,
     wafer_padding: float = 0.0,
@@ -37,6 +38,7 @@ def get_mesh(
         type: one of "xy", "uz", or "3D". Determines the type of mesh to return.
         layer_stack: LayerStack object containing layer information.
         layer_physical_map: by default, physical are tagged with layername; this dict allows you to specify custom mappings.
+        layer_meshbool_map: by default, all polygons on layer_stack layers are meshed; this dict allows you set True of False to the meshing of given layers.
         z: used to define z-slice for xy meshing.
         xsection_bounds: used to define in-plane line for uz meshing.
         wafer_padding: padding beyond bbox to add to WAFER layers.
@@ -84,6 +86,16 @@ def get_mesh(
         for layer_name in layer_stack.layers.keys():
             if layer_name not in layer_physical_map.keys():
                 layer_physical_map[layer_name] = layer_name
+
+    # Default meshing flags (all True)
+    if layer_meshbool_map is None:
+        layer_meshbool_map = {}
+        for layer_name in layer_stack.layers.keys():
+            layer_meshbool_map[layer_name] = True
+    else:
+        for layer_name in layer_stack.layers.keys():
+            if layer_name not in layer_physical_map.keys():
+                layer_meshbool_map[layer_name] = True
 
     if type == "xy":
         if z is None:

--- a/gplugins/gmsh/get_mesh.py
+++ b/gplugins/gmsh/get_mesh.py
@@ -22,6 +22,7 @@ def get_mesh(
     component: ComponentSpec,
     type: str,
     layer_stack: LayerStack,
+    layer_physical_map: dict | None = None,
     z: float | None = None,
     xsection_bounds=None,
     wafer_padding: float = 0.0,
@@ -35,6 +36,7 @@ def get_mesh(
         component: component
         type: one of "xy", "uz", or "3D". Determines the type of mesh to return.
         layer_stack: LayerStack object containing layer information.
+        layer_physical_map: by default, physical are tagged with layername; this dict allows you to specify custom mappings.
         z: used to define z-slice for xy meshing.
         xsection_bounds: used to define in-plane line for uz meshing.
         wafer_padding: padding beyond bbox to add to WAFER layers.
@@ -73,6 +75,16 @@ def get_mesh(
     else:
         new_resolutions = None
 
+    # Default layer labels
+    if layer_physical_map is None:
+        layer_physical_map = {}
+        for layer_name in layer_stack.layers.keys():
+            layer_physical_map[layer_name] = layer_name
+    else:
+        for layer_name in layer_stack.layers.keys():
+            if layer_name not in layer_physical_map.keys():
+                layer_physical_map[layer_name] = layer_name
+
     if type == "xy":
         if z is None:
             raise ValueError(
@@ -85,6 +97,7 @@ def get_mesh(
             layer_stack=layer_stack,
             default_characteristic_length=default_characteristic_length,
             resolutions=new_resolutions,
+            layer_physical_map=layer_physical_map,
             **kwargs,
         )
     elif type == "uz":
@@ -100,6 +113,7 @@ def get_mesh(
             layer_stack=layer_stack,
             default_characteristic_length=default_characteristic_length,
             resolutions=new_resolutions,
+            layer_physical_map=layer_physical_map,
             **kwargs,
         )
     elif type == "3D":
@@ -108,6 +122,7 @@ def get_mesh(
             layer_stack=layer_stack,
             default_characteristic_length=default_characteristic_length,
             resolutions=new_resolutions,
+            layer_physical_map=layer_physical_map,
             **kwargs,
         )
     else:

--- a/gplugins/gmsh/tests/test_custom_names.py
+++ b/gplugins/gmsh/tests/test_custom_names.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.pdk import get_layer_stack
+from gdsfactory.technology import LayerStack
+
+from gplugins.gmsh.get_mesh import get_mesh
+
+
+def test_custom_physical_uz() -> None:
+    waveguide = gf.components.straight_pin(length=10, taper=None)
+
+    filtered_layer_stack = LayerStack(
+        layers={
+            k: get_layer_stack().layers[k]
+            for k in (
+                "slab90",
+                "core",
+                "via_contact",
+            )
+        }
+    )
+
+    layer_physical_map = {
+        "slab90": "silicon",
+        "core": "silicon",
+        "via_contact": "metal",
+    }
+
+    mesh = get_mesh(
+        type="uz",
+        component=waveguide,
+        xsection_bounds=[(4, -15), (4, 15)],
+        layer_stack=filtered_layer_stack,
+        layer_physical_map=layer_physical_map,
+        background_tag="Oxide",
+        filename="uzmesh_ref.msh",
+    )
+
+    for value in layer_physical_map.values():
+        assert value in mesh.cell_sets_dict.keys()
+
+
+def test_custom_physical_xy() -> None:
+    waveguide = gf.components.straight_pin(length=10, taper=None)
+
+    filtered_layer_stack = LayerStack(
+        layers={
+            k: get_layer_stack().layers[k]
+            for k in (
+                "slab90",
+                "core",
+                "via_contact",
+            )
+        }
+    )
+
+    layer_physical_map = {
+        "slab90": "silicon",
+        "core": "silicon",
+        "via_contact": "metal",
+    }
+
+    mesh = get_mesh(
+        type="xy",
+        component=waveguide,
+        z=0.09,
+        layer_stack=filtered_layer_stack,
+        layer_physical_map=layer_physical_map,
+        background_tag="Oxide",
+        filename="xymesh.msh",
+    )
+
+    for value in layer_physical_map.values():
+        assert value in mesh.cell_sets_dict.keys()
+
+
+def test_custom_physical_xyz() -> None:
+    waveguide = gf.components.straight_pin(length=10, taper=None)
+
+    filtered_layer_stack = LayerStack(
+        layers={
+            k: get_layer_stack().layers[k]
+            for k in (
+                "slab90",
+                "core",
+                "via_contact",
+            )
+        }
+    )
+
+    layer_physical_map = {
+        "slab90": "silicon",
+        "core": "silicon",
+        "via_contact": "metal",
+    }
+
+    mesh = get_mesh(
+        type="3D",
+        component=waveguide,
+        layer_stack=filtered_layer_stack,
+        layer_physical_map=layer_physical_map,
+        background_tag="Oxide",
+        filename="xyzmesh.msh",
+    )
+
+    for value in layer_physical_map.values():
+        assert value in mesh.cell_sets_dict.keys()
+
+
+if __name__ == "__main__":
+    test_custom_physical_uz()

--- a/gplugins/gmsh/tests/test_meshing_3D.py
+++ b/gplugins/gmsh/tests/test_meshing_3D.py
@@ -5,7 +5,7 @@ from gdsfactory.generic_tech import LAYER
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 
-from gplugins.gmsh.xyz_mesh import xyz_mesh
+from gplugins.gmsh.get_mesh import get_mesh
 
 
 def test_gmsh_xyz_mesh() -> None:
@@ -43,7 +43,8 @@ def test_gmsh_xyz_mesh() -> None:
     resolutions = {
         "core": {"resolution": 0.3},
     }
-    xyz_mesh(
+    get_mesh(
+        type="3D",
         component=c,
         layer_stack=filtered_layer_stack,
         resolutions=resolutions,

--- a/gplugins/gmsh/uz_xsection_mesh.py
+++ b/gplugins/gmsh/uz_xsection_mesh.py
@@ -194,6 +194,7 @@ def uz_xsection_mesh(
     component: ComponentOrReference,
     xsection_bounds: tuple[tuple[float, float], tuple[float, float]],
     layer_stack: LayerStack,
+    layer_physical_map: dict,
     resolutions: dict | None = None,
     default_characteristic_length: float = 0.5,
     background_tag: str | None = None,
@@ -278,6 +279,7 @@ def uz_xsection_mesh(
         model=model,
         scale_factor=global_scaling_premesh,
         resolutions=resolutions,
+        layer_physical_map=layer_physical_map,
     )
 
     # Add background polygon

--- a/gplugins/gmsh/xy_xsection_mesh.py
+++ b/gplugins/gmsh/xy_xsection_mesh.py
@@ -58,6 +58,7 @@ def xy_xsection_mesh(
     component: ComponentOrReference,
     z: float,
     layer_stack: LayerStack,
+    layer_physical_map: dict,
     resolutions: dict | None = None,
     default_characteristic_length: float = 0.5,
     background_tag: str | None = None,
@@ -150,6 +151,7 @@ def xy_xsection_mesh(
         model=model,
         scale_factor=global_scaling_premesh,
         resolutions=resolutions,
+        layer_physical_map=layer_physical_map,
     )
 
     # Mesh

--- a/gplugins/gmsh/xyz_mesh.py
+++ b/gplugins/gmsh/xyz_mesh.py
@@ -130,6 +130,7 @@ def define_prisms(
 def xyz_mesh(
     component: ComponentOrReference,
     layer_stack: LayerStack,
+    layer_physical_map: dict,
     resolutions: dict | None = None,
     default_characteristic_length: float = 0.5,
     background_tag: str | None = None,

--- a/gplugins/gmsh/xyz_mesh.py
+++ b/gplugins/gmsh/xyz_mesh.py
@@ -75,6 +75,7 @@ def define_edgeport(
 def define_prisms(
     layer_polygons_dict: dict,
     layer_stack: LayerStack,
+    layer_physical_map: dict,
     model: Any,
     resolutions: dict,
     scale_factor: float = 1,
@@ -84,6 +85,7 @@ def define_prisms(
     Args:
         layer_polygons_dict: dictionary of polygons for each layer
         layer_stack: gdsfactory LayerStack to parse
+        layer_physical_map: map layer names to physical names
         model: meshwell Model object
         resolutions: Pairs {"layername": {"resolution": float, "distance": "float}} to roughly control mesh refinement.
         scale_factor: scaling factor to apply to the polygons (default: 1)
@@ -120,7 +122,9 @@ def define_prisms(
                 model=model,
                 resolution=resolutions.get(layername, None),
                 mesh_order=buffered_layer_stack.layers.get(layername).mesh_order,
-                physical_name=layername,
+                physical_name=layer_physical_map[layername]
+                if layername in layer_physical_map
+                else layername,
             )
         )
 
@@ -255,6 +259,7 @@ def xyz_mesh(
         model=model,
         scale_factor=global_scaling_premesh,
         resolutions=resolutions,
+        layer_physical_map=layer_physical_map,
     )
 
     # Add edgeports


### PR DESCRIPTION
Can now pass " layer_physical_map" dict in get_mesh to map the layer names to other names

Useful, for instance, to tag multiple layers as one physical e.g. "metal"

@HelgeGehring @mdecea 