### PR TITLE
Fix vlsir tests

### DIFF
--- a/gplugins/klayout/get_netlist.py
+++ b/gplugins/klayout/get_netlist.py
@@ -54,7 +54,10 @@ def get_l2n(
     # define the layers to be extracted
     for l_idx in c.kcl.layer_indexes():
         layer_info = c.kcl.get_info(l_idx)
-        names = reversed_layer_map[(layer_info.layer, layer_info.datatype)]
+        names = reversed_layer_map.get(
+            (layer_info.layer, layer_info.datatype),
+            {f"{layer_info.layer}_{layer_info.datatype}"},
+        )
         try:
             same_name_as_in_connections = next(iter(correct_layer_names & names))
         except StopIteration:

--- a/gplugins/meow/test_meow_simulation.py
+++ b/gplugins/meow/test_meow_simulation.py
@@ -1,11 +1,25 @@
+import importlib
+
 import gdsfactory as gf
 import numpy as np
+import pytest
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 
 from gplugins.meow import MEOW
 
 
+@pytest.fixture
+def reload_pdk_after():
+    """
+    Reload PDK after test. This is required as MEOW modifies the PDK layers.
+    See https://github.com/gdsfactory/gplugins/issues/187
+    """
+    yield
+    importlib.reload(gf)
+
+
+@pytest.mark.usefixtures("reload_pdk_after")
 def test_meow_defaults() -> None:
     c = gf.components.taper_cross_section_linear()
     filtered_layer_stack = LayerStack(
@@ -43,6 +57,7 @@ def test_meow_defaults() -> None:
     assert abs(sp["o2@0,o2@0"]) < 0.05
 
 
+@pytest.mark.usefixtures("reload_pdk_after")
 def test_cells() -> None:
     layer_stack = LayerStack(
         layers={


### PR DESCRIPTION
This PR fixes the vlsir test failing if the whole test suite is run. The problem stemmed from the meow plugin modifying layers in the active pdk while not adding corresponding LayerViews.

The solution implemented here is to reload gdsfactory after running the meow tests.

_Drafted until test confirmed to run._

Closes https://github.com/gdsfactory/gplugins/issues/187