### PR TITLE
Support non-fully-connected netlists in `plot_nets`

### DIFF
--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 from pathlib import Path
 
@@ -5,8 +6,14 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 
-def plot_nets(filepath: str | Path) -> None:
-    """Plots the connectivity between the components in the GDS file."""
+def plot_nets(filepath: str | Path, fully_connected: bool = False) -> None:
+    """Plots the connectivity between the components in the GDS file.
+
+    Args:
+        filepath: Path to the GDS file.
+        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
+            going through other elements (False).
+    """
     filepath = Path(filepath)
     code = filepath.read_text()
     names = re.findall(r"name\('([\w,]+)'\)", code)
@@ -17,9 +24,12 @@ def plot_nets(filepath: str | Path) -> None:
     # Adding nodes and edges based on names
     for name_group in names:
         individual_names = name_group.split(",")
-        for i in range(len(individual_names)):
-            for j in range(i + 1, len(individual_names)):
-                G_connectivity.add_edge(individual_names[i], individual_names[j])
+        if fully_connected:
+            G_connectivity.add_edges_from(itertools.combinations(individual_names, 2))
+        else:
+            G_connectivity.add_edges_from(
+                zip(individual_names[:-1], individual_names[1:])
+            )
 
     # Plotting the graph
     plt.figure(figsize=(8, 6))


### PR DESCRIPTION
Adds a parameter `fully_connected` to `plot_nets` for plotting nets as below


![image](https://github.com/gdsfactory/gplugins/assets/7860886/049c63bd-19eb-4b1e-8117-fe60abd290a7)


as opposed to

![image](https://github.com/gdsfactory/gplugins/assets/7860886/56d02efe-21a5-48c1-a9c3-c60a52a6125e)


Closes #184