### PR TITLE
Parametrize VLSIR netlist export test and cache Package

### DIFF
--- a/gplugins/vlsir/tests/test_vlsir.py
+++ b/gplugins/vlsir/tests/test_vlsir.py
@@ -1,44 +1,49 @@
 import pytest
 from gdsfactory.samples.demo.lvs import pads_correct
+from vlsir.circuit_pb2 import (
+    Package,
+)
 
 from gplugins.common.config import PATH
 from gplugins.klayout.get_netlist import get_netlist
 from gplugins.vlsir import export_netlist, kdb_vlsir
 
 
-def test_kdb_vlsir() -> None:
-    """Test the conversion from KLayout DB Netlist to VLSIR Package"""
+@pytest.fixture(scope="session")
+def pkg() -> Package:
+    """Get VLSIR Package for `pads_correct`. Cached for session scope."""
 
     c = pads_correct()
     gdspath = c.write_gds()
     kdbnet = get_netlist(gdspath)
-    pkg = kdb_vlsir(kdbnet, domain="gplugins.klayout.example")
+    return kdb_vlsir(kdbnet, domain="gplugins.klayout.example")
+
+
+def test_kdb_vlsir(pkg) -> None:
+    """Test the conversion from KLayout DB Netlist to VLSIR Package"""
+
     assert pkg is not None
     assert len(pkg.modules) == 7
     assert len(pkg.modules[6].instances) == 10
     assert pkg.modules[6].name == "pads_correct"
 
 
-def test_export_netlist() -> None:
+@pytest.mark.parametrize("spice_format", ["spice", "spectre", "xyce", "verilog"])
+def test_export_netlist(pkg, spice_format) -> None:
     """Test the export of a VLSIR Package to a netlist in the supported formats"""
 
-    c = pads_correct()
-    gdspath = c.write_gds()
-    kdbnet = get_netlist(gdspath)
-    pkg = kdb_vlsir(kdbnet, domain="gplugins.klayout.example")
     outfile = PATH.module / "vlsir" / "tests" / "resources" / "pads_correct"
     format_to_suffix = {
         "spice": ".sp",
         "spectre": ".scs",
         "xyce": ".cir",
     }
-    for fmt in ["spice", "spectre", "xyce", "verilog"]:
-        if fmt == "verilog":
-            with pytest.raises(NotImplementedError):
-                export_netlist(pkg, fmt=fmt)
-        else:
-            outpath = outfile.with_suffix(format_to_suffix[fmt])
-            with open(outpath, "w") as f:
-                export_netlist(pkg, fmt=fmt, dest=f)
-            with open(outpath) as f:
-                assert f.read() is not None
+    if spice_format == "verilog":
+        with pytest.raises(NotImplementedError):
+            export_netlist(pkg, fmt=spice_format)
+    else:
+        outpath = outfile.with_suffix(format_to_suffix[spice_format])
+        with open(outpath, "w") as f:
+            export_netlist(pkg, fmt=spice_format, dest=f)
+        with open(outpath) as f:
+            assert f.read() is not None


### PR DESCRIPTION
This PR adjusts the vlsir netlist export tests a bit:
* VLSIR Package is cached for the tests instead of recreating a component
* Different formats are tested with pytest parametrization as opposed to a for-loop. This allows seeing if a specific format would stop working.