### PR TITLE
Improve dataprep

### DIFF
--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -32,7 +32,8 @@ def _is_layer(value: any) -> bool:
         return True
     else:
         return False
-    
+
+
 def _assert_is_layer(value: any) -> None:
     if not _is_layer(value):
         raise ValueError(f"Layer must be a tuple of two integers. Got {value!r}")
@@ -111,7 +112,6 @@ class RegionCollection:
         _assert_is_layer(layer)
         self.regions[layer] = region
 
-    
     def __contains__(self, item):
         # checks if the layout contains the given layer
         _assert_is_layer(item)

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -98,6 +98,12 @@ class RegionCollection:
             raise ValueError(f"Layer must be a tuple of two integers. Got {layer!r}")
         self.regions[layer] = region
 
+    
+    def __contains__(self, item):
+        # checks if the layout contains the given layer
+        layer, datatype = item
+        return self.lib.find_layer(layer, datatype) is not None
+
     def write_gds(self, gdspath: PathType = GDSDIR_TEMP / "out.gds", **kwargs) -> None:
         """Write gds.
 
@@ -134,10 +140,11 @@ class RegionCollection:
         c = kf.KCell(cellname, self.lib)
         if keep_original:
             c.copy_tree(self.layout)
-            c.flatten()
+            for layer in self.regions:
+                layer_id = self.lib.layer(layer[0], layer[1])
+                self.lib.layout.clear_layer(layer_id)
 
         for layer, region in self.regions.items():
-            c.shapes(self.lib.layer(layer[0], layer[1])).clear()
             c.shapes(self.lib.layer(layer[0], layer[1])).insert(region)
         return c
 

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -23,6 +23,21 @@ def copy(region: kdb.Region) -> kdb.Region:
     return region.dup()
 
 
+def _is_layer(value: any) -> bool:
+    try:
+        layer, datatype = value
+    except Exception:
+        return False
+    if isinstance(layer, int) and isinstance(datatype, int):
+        return True
+    else:
+        return False
+    
+def _assert_is_layer(value: any) -> None:
+    if not _is_layer(value):
+        raise ValueError(f"Layer must be a tuple of two integers. Got {value!r}")
+
+
 class Region(kdb.Region):
     def __iadd__(self, offset) -> kdb.Region:
         """Adds an offset to the layer."""
@@ -81,8 +96,7 @@ class RegionCollection:
         self.regions = {}
 
     def __getitem__(self, layer: tuple[int, int]) -> Region:
-        if len(layer) != 2:
-            raise ValueError(f"Layer must be a tuple of two integers. Got {layer!r}")
+        _assert_is_layer(layer)
 
         if layer in self.regions:
             return self.regions[layer]
@@ -94,13 +108,13 @@ class RegionCollection:
         return region
 
     def __setitem__(self, layer: tuple[int, int], region: Region) -> None:
-        if len(layer) != 2:
-            raise ValueError(f"Layer must be a tuple of two integers. Got {layer!r}")
+        _assert_is_layer(layer)
         self.regions[layer] = region
 
     
     def __contains__(self, item):
         # checks if the layout contains the given layer
+        _assert_is_layer(item)
         layer, datatype = item
         return self.lib.find_layer(layer, datatype) is not None
 

--- a/gplugins/klayout/tests/test_dataprep_regions.py
+++ b/gplugins/klayout/tests/test_dataprep_regions.py
@@ -92,6 +92,7 @@ def test_RegionCollection_init(region_collection) -> None:
     # Check if the RegionCollection was initialized properly
     assert region_collection[(1, 0)]
 
+
 def test_region_collection_contains(region_collection) -> None:
     assert l.FLOORPLAN in region_collection
 

--- a/gplugins/klayout/tests/test_dataprep_regions.py
+++ b/gplugins/klayout/tests/test_dataprep_regions.py
@@ -92,6 +92,9 @@ def test_RegionCollection_init(region_collection) -> None:
     # Check if the RegionCollection was initialized properly
     assert region_collection[(1, 0)]
 
+def test_region_collection_contains(region_collection) -> None:
+    assert l.FLOORPLAN in region_collection
+
 
 if __name__ == "__main__":
     import pathlib


### PR DESCRIPTION
This PR primarily does two things

1. Avoids flattening of untouched layers from the source gds when included in the output with `keep_original=True`
2. Allows the user to check if a layer exists in the RegionCollection by implementing the `__contains__` magic method