### PR TITLE
Write output to a new library so we can reuse cell names

### DIFF
--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -151,15 +151,16 @@ class RegionCollection:
         if cellname == "Unnamed":
             uid = str(uuid.uuid4())[:8]
             cellname += f"_{uid}"
-        c = kf.KCell(cellname, self.lib)
+        output_lib = kf.kcell.KCLayout("output")
+        c = kf.KCell(cellname, output_lib)
         if keep_original:
             c.copy_tree(self.layout)
             for layer in self.regions:
-                layer_id = self.lib.layer(layer[0], layer[1])
-                self.lib.layout.clear_layer(layer_id)
+                layer_id = output_lib.layer(layer[0], layer[1])
+                output_lib.layout.clear_layer(layer_id)
 
         for layer, region in self.regions.items():
-            c.shapes(self.lib.layer(layer[0], layer[1])).insert(region)
+            c.shapes(output_lib.layer(layer[0], layer[1])).insert(region)
         return c
 
     def show(self, gdspath: PathType = GDSDIR_TEMP / "out.gds", **kwargs) -> None:

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -118,17 +118,18 @@ class RegionCollection:
         layer, datatype = item
         return self.lib.find_layer(layer, datatype) is not None
 
-    def write_gds(self, gdspath: PathType = GDSDIR_TEMP / "out.gds", **kwargs) -> None:
+    def write_gds(self, gdspath: PathType = GDSDIR_TEMP / "out.gds", top_cell_name: str | None = None, keep_original: bool = True) -> None:
         """Write gds.
 
         Args:
-            gdspath: gdspath.
-
-        Keyword Args:
-            keep_original: keep original cell.
-            cellname: for top cell.
+            gdspath: output gds path
+            top_cell_name: name to use for the top cell of the output library
+            keep_original: if True, keeps all original cells (and hierarchy, to the extent possible) in the output. If false, only explicitly defined layers are output.
         """
-        c = self.get_kcell(**kwargs)
+        # use the working top cell name if not provided
+        if top_cell_name is None:
+            top_cell_name = self.layout.name
+        c = self.get_kcell(cellname=top_cell_name, keep_original=keep_original)
         c.write(gdspath)
 
     def plot(self, **kwargs):
@@ -151,6 +152,7 @@ class RegionCollection:
         if cellname == "Unnamed":
             uid = str(uuid.uuid4())[:8]
             cellname += f"_{uid}"
+
         output_lib = kf.kcell.KCLayout("output")
         c = kf.KCell(cellname, output_lib)
         if keep_original:


### PR DESCRIPTION
This is a simple update which writes the dataprep output to a new layout, allowing us to write back to the same cell names. By default, we now also maintain the input top cell name, which I think is usually the desired result.

@joamatab 
@sebastian-goeldi