### PR TITLE
Fix port centers in z

### DIFF
--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -295,7 +295,7 @@ class Tidy3DComponent(LayeredComponentBase):
             shutoff=shutoff,
         )
 
-        ports = self.get_ports(mode_spec, port_size_mult, cz)
+        ports = self.get_ports(mode_spec, port_size_mult)
 
         modeler = ComponentModeler(
             simulation=sim,

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -270,7 +270,7 @@ class Tidy3DComponent(LayeredComponentBase):
             case str():
                 cz = self.get_layer_center(center_z)[2]
             case None:
-                cz = self.center[2]
+                cz = np.mean(list({c[2] for c in self.port_centers}))
             case _:
                 raise ValueError(f"Invalid center_z: {center_z}")
 


### PR DESCRIPTION
- Set simulation center z to average z of all ports
- Do not place all ports at sim center but instead derive from actual port centers
