### PR TITLE
Bump max gdsfactory version to accept latest one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory[cad]>=7.8.1,<7.9",
+  "gdsfactory[cad]>=7.8.1,<7.10",
   "pint"
 ]
 description = "gdsfactory plugins"


### PR DESCRIPTION
I think this is causing problems when trying to install latest gdsfactory and gplugins. Gdsfactory will have to resort to an older version.