### PR TITLE
Include tqdm in project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 dependencies = [
   "gdsfactory>=7.10.1",
-  "pint"
+  "pint",
+  "tqdm",
 ]
 description = "gdsfactory plugins"
 keywords = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
   "gdsfactory>=7.10.1",
   "pint",
-  "tqdm",
+  "tqdm"
 ]
 description = "gdsfactory plugins"
 keywords = ["python"]


### PR DESCRIPTION
Lots of the code (specifically in modes) uses tqdm without listing it as an install dependency, might as well include it and avoid confusion.