### PR TITLE
retire devsim doc

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -20,7 +20,7 @@ parts:
       - file: plugins_process
         sections:
           - file: notebooks/femwell_02_heater
-          - file: notebooks/devsim_01_pin_waveguide
+          # - file: notebooks/devsim_01_pin_waveguide
           - file: notebooks/tcad_02_analytical_process
           - file: notebooks/tcad_03_numerical_implantation
           - file: notebooks/elmer_01_electrostatic


### PR DESCRIPTION
while devsim is usable from gdsfactory meshing (I use it personally), the documentation is severely outdated

removing it from the docs for now