### PR TITLE
Mention correct pinned pyvis version

### DIFF
--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -146,7 +146,7 @@ def plot_nets(
             from pyvis.network import Network
         except ModuleNotFoundError as e:
             raise UserWarning(
-                "You need to `pip install pyvis` or `gplugins[klayout]`"
+                "You need to `pip install pyvis<=0.3.1` or `gplugins[klayout]`"
             ) from e
 
         net = Network(


### PR DESCRIPTION
I stumbled on instarlling the wrong version. This should avoid others doing the same.