### PR TITLE
Improve KLayout-based SPICE handling to support Calibre LVS with generic devices

### DIFF
--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -15,7 +15,6 @@ def _get_subcircuit_name(subcircuit: kdb.SubCircuit) -> str:
 
 def netlist_to_networkx(
     netlist: kdb.Netlist,
-    fully_connected: bool = False,
     include_labels: bool = True,
     only_most_complex: bool = False,
 ) -> nx.Graph:
@@ -23,9 +22,7 @@ def netlist_to_networkx(
 
     Args:
         netlist: The KLayout DB `Netlist` to convert to a networkx `Graph`.
-        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
-            going through other elements (False).
-        include_labels: Whether to include labels in the graph connected to corresponding cells.
+        include_labels: Whether to include net labels in the graph connected to corresponding cells.
         only_most_complex: Whether to plot only the circuit with most connections or not.
             Helpful for not plotting subcircuits separately.
 
@@ -41,12 +38,8 @@ def netlist_to_networkx(
     if only_most_complex:
         top_circuits = (max(top_circuits, key=lambda x: x.pin_count()),)
 
+    all_used_nets = set()
     for circuit in top_circuits:
-        # first flatten components that won't be kept
-        # for subcircuit in circuit.each_subcircuit():
-        #     if subcircuit.name in {"TODO"}:
-        #         circuit.flatten_subcircuit(subcircuit)
-
         for device in circuit.each_device():
             # Gather properties of Device class
             device_class = device.device_class()
@@ -64,49 +57,24 @@ def netlist_to_networkx(
             ]
             device_name = f"{device_class.name}_{device.expanded_name()}"
 
-            # Get subcircuit pins if they exist (hierarchical export from KLayout)
-            # net_pins = [
-            #     _get_subcircuit_name(subcircuit_pin_ref.subcircuit())
-            #     for subcircuit_pin_ref in net.each_subcircuit_pin()
-            # ]
-            # if net_pins:
-            #     breakpoint()
-            # or use all pins (flat like from Cadence SPICE)
-            # if not net_pins:
-            #     net_pins.extend(pin_ref.pin().name() for pin_ref in net.each_pin())
-
-            # Assumed lone net with only label info
-            # if (
-            #     include_labels
-            #     and net.expanded_name()
-            #     and "," not in net.expanded_name()
-            # ):
-            #     G.add_edges_from(zip(net_pins, [net.name] * len(net_pins)))
-
-            # device_names_connected_to_nets = [
-            #     _get_subcircuit_name(subcircuit_pin_ref.subcircuit())
-            #     for subcircuit_pin_ref in net.each_subcircuit_pin()
-            # ]
-
+            # Create NetworkX representation
             G.add_node(device_name, **parameters)
             for net in nets:
-                G.add_edge(device_name, net.expanded_name())
+                net_name = net.expanded_name()
+                G.add_edge(device_name, net_name)
+                all_used_nets.add(net_name)
 
-            # if fully_connected:
-            #     G.add_edges_from(itertools.combinations(net_pins, 2))
-            # else:
-            #     G.add_edges_from(zip(net_pins[:-1], net_pins[1:]))
-
-    # TODO
-    # for parameter_name, parameter_values in TODO:
-    #     nx.set_node_attributes(G, parameter_values, name=parameter_name)
+    if not include_labels:
+        for node in all_used_nets:
+            connections = list(G.neighbors(node))
+            G.add_edges_from(itertools.combinations(connections, r=2))
+            G.remove_node(node)
 
     return G
 
 
 def networkx_from_file(
     filepath: str | Path,
-    fully_connected: bool = False,
     include_labels: bool = True,
     only_most_complex: bool = False,
     **kwargs,
@@ -115,8 +83,6 @@ def networkx_from_file(
     Args:
         filepath: Path to the KLayout LayoutToNetlist file or a SPICE netlist.
             File extensions should be `.l2n` and `.spice`, respectively.
-        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
-            going through other elements (False).
         include_labels: Whether to include labels in the graph connected to corresponding cells.
         only_most_complex: Whether to plot only the circuit with most connections or not.
             Helpful for not plotting subcircuits separately.
@@ -140,7 +106,6 @@ def networkx_from_file(
     # Creating a graph for the connectivity
     return netlist_to_networkx(
         netlist,
-        fully_connected=fully_connected,
         include_labels=include_labels,
         only_most_complex=only_most_complex,
     )

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -1,5 +1,6 @@
 import itertools
 from pathlib import Path
+from typing import Optional, Type
 
 import klayout.db as kdb
 import networkx as nx
@@ -8,15 +9,16 @@ from gdsfactory.config import logger
 from gplugins.klayout.netlist_spice_reader import CalibreSpiceReader
 
 
-def _get_subcircuit_name(subcircuit: kdb.SubCircuit) -> str:
-    """Get the _cell name_ of a `SubCircuit` instance"""
-    return f"{subcircuit.circuit_ref().name}{subcircuit.expanded_name()}"
+def _get_device_name(device: kdb.Device) -> str:
+    """Get a unique name for a ``Device`` instance."""
+    return f"{device.device_class().name}_{device.expanded_name()}"
 
 
 def netlist_to_networkx(
     netlist: kdb.Netlist,
     include_labels: bool = True,
     only_most_complex: bool = False,
+    spice_reader_instance: kdb.NetlistSpiceReaderDelegate | None = None,
 ) -> nx.Graph:
     """Convert a KLayout DB `Netlist` to a networkx graph.
 
@@ -25,6 +27,8 @@ def netlist_to_networkx(
         include_labels: Whether to include net labels in the graph connected to corresponding cells.
         only_most_complex: Whether to plot only the circuit with most connections or not.
             Helpful for not plotting subcircuits separately.
+        spice_reader_instance: The KLayout Spice reader that was used for parsing SPICE netlists.
+            Used for fetching string parameter values from a stored mapping.
 
     Returns:
         A networkx `Graph` representing the connectivity of the `Netlist`.
@@ -48,14 +52,21 @@ def netlist_to_networkx(
 
             # Gather values for specific Device instance
             parameters = {
-                parameter.name: device.parameter(parameter.name)
+                parameter.name: (
+                    device.parameter(parameter.name)
+                    if not spice_reader_instance
+                    else spice_reader_instance.integer_to_string_map.get(
+                        device.parameter(parameter.name),
+                        device.parameter(parameter.name),
+                    )
+                )
                 for parameter in parameter_definitions
             }
             nets = [
                 device.net_for_terminal(terminal.name)
                 for terminal in terminal_definitions
             ]
-            device_name = f"{device_class.name}_{device.expanded_name()}"
+            device_name = _get_device_name(device)
 
             # Create NetworkX representation
             G.add_node(device_name, **parameters)
@@ -77,6 +88,7 @@ def networkx_from_file(
     filepath: str | Path,
     include_labels: bool = True,
     only_most_complex: bool = False,
+    spice_reader: type[kdb.NetlistSpiceReaderDelegate] = CalibreSpiceReader,
     **kwargs,
 ) -> nx.Graph:
     """Returns a networkx Graph from a SPICE netlist file or KLayout LayoutToNetlist.
@@ -86,15 +98,16 @@ def networkx_from_file(
         include_labels: Whether to include labels in the graph connected to corresponding cells.
         only_most_complex: Whether to plot only the circuit with most connections or not.
             Helpful for not plotting subcircuits separately.
+        spice_reader: The KLayout Spice reader to use for parsing SPICE netlists.
     """
-
+    spice_reader_instance = None
     match Path(filepath).suffix:
         case ".l2n" | ".txt":
             l2n = kdb.LayoutToNetlist()
             l2n.read(str(filepath))
             netlist = l2n.netlist()
         case ".cir" | ".sp" | ".spi" | ".spice":
-            reader = kdb.NetlistSpiceReader(CalibreSpiceReader())
+            reader = kdb.NetlistSpiceReader(spice_reader_instance := spice_reader())
             netlist = kdb.Netlist()
             netlist.read(str(filepath), reader)
         case _:
@@ -108,4 +121,5 @@ def networkx_from_file(
         netlist,
         include_labels=include_labels,
         only_most_complex=only_most_complex,
+        spice_reader_instance=spice_reader_instance,
     )

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -36,7 +36,6 @@ def netlist_to_networkx(
         A networkx `Graph` representing the connectivity of the `Netlist`.
     """
     G = nx.Graph()
-    # netlist.simplify()
     netlist.flatten()
 
     top_circuits = list(

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -1,11 +1,10 @@
-from collections import Counter
 import itertools
 from pathlib import Path
-from gdsfactory.typings import PathType
 
 import klayout.db as kdb
 import networkx as nx
 from gdsfactory.config import logger
+from gdsfactory.typings import PathType
 
 from gplugins.klayout.netlist_spice_reader import (
     CalibreSpiceReader,
@@ -45,8 +44,9 @@ def netlist_to_networkx(
     )
 
     if top_cell:
-        top_circuits = (next(c for c in top_circuits if c.name.casefold() == top_cell.casefold()),)
-
+        top_circuits = (
+            next(c for c in top_circuits if c.name.casefold() == top_cell.casefold()),
+        )
 
     # unique_net_counter = Counter()
     all_used_nets = set()
@@ -82,9 +82,7 @@ def netlist_to_networkx(
                 # net_name = (
                 #     f"{net.expanded_name()}_{unique_net_counter[net.expanded_name()]}"
                 # )
-                net_name = (
-                    f"{net.expanded_name()}"
-                )
+                net_name = f"{net.expanded_name()}"
                 G.add_edge(device_name, net_name)
                 all_used_nets.add(net_name)
 

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -58,12 +58,11 @@ def netlist_to_networkx(
             # Gather values for specific Device instance
             parameters = {
                 parameter.name: (
-                    device.parameter(parameter.name)
-                    if not spice_reader_instance
-                    else spice_reader_instance.integer_to_string_map.get(
-                        int(device.parameter(parameter.name)),
-                        device.parameter(parameter.name),
-                    )
+                    spice_reader_instance.integer_to_string_map.get(
+                                            int(device.parameter(parameter.name)),
+                                            device.parameter(parameter.name),
+                                        ) if spice_reader_instance else device.parameter(parameter.name)
+
                 )
                 for parameter in parameter_definitions
             }

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -37,6 +37,8 @@ def netlist_to_networkx(
         A networkx `Graph` representing the connectivity of the `Netlist`.
     """
     G = nx.Graph()
+    # netlist.simplify()
+    netlist.flatten()
 
     top_circuits = list(
         itertools.islice(netlist.each_circuit_top_down(), netlist.top_circuit_count())
@@ -46,7 +48,7 @@ def netlist_to_networkx(
         top_circuits = (next(c for c in top_circuits if c.name.casefold() == top_cell.casefold()),)
 
 
-    unique_net_counter = Counter()
+    # unique_net_counter = Counter()
     all_used_nets = set()
     for circuit in top_circuits:
         for device in circuit.each_device():
@@ -76,9 +78,12 @@ def netlist_to_networkx(
             # Create NetworkX representation
             G.add_node(device_name, **parameters)
             for net in nets:
-                unique_net_counter.update([net.expanded_name()])
+                # unique_net_counter.update([net.expanded_name()])
+                # net_name = (
+                #     f"{net.expanded_name()}_{unique_net_counter[net.expanded_name()]}"
+                # )
                 net_name = (
-                    f"{net.expanded_name()}_{unique_net_counter[net.expanded_name()]}"
+                    f"{net.expanded_name()}"
                 )
                 G.add_edge(device_name, net_name)
                 all_used_nets.add(net_name)
@@ -88,8 +93,6 @@ def netlist_to_networkx(
             connections = list(G.neighbors(node))
             G.add_edges_from(itertools.combinations(connections, r=2))
             G.remove_node(node)
-
-    breakpoint()
 
     return G
 

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -59,10 +59,11 @@ def netlist_to_networkx(
             parameters = {
                 parameter.name: (
                     spice_reader_instance.integer_to_string_map.get(
-                                            int(device.parameter(parameter.name)),
-                                            device.parameter(parameter.name),
-                                        ) if spice_reader_instance else device.parameter(parameter.name)
-
+                        int(device.parameter(parameter.name)),
+                        device.parameter(parameter.name),
+                    )
+                    if spice_reader_instance
+                    else device.parameter(parameter.name)
                 )
                 for parameter in parameter_definitions
             }

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -1,0 +1,77 @@
+
+import itertools
+from collections.abc import Collection
+from itertools import combinations
+from pathlib import Path
+
+import klayout.db as kdb
+import matplotlib.pyplot as plt
+import networkx as nx
+from gdsfactory.config import logger
+
+from gplugins.klayout.netlist_spice_reader import NoCommentReader
+
+
+def _get_subcircuit_name(subcircuit: kdb.SubCircuit) -> str:
+    """Get the _cell name_ of a `SubCircuit` instance"""
+    return f"{subcircuit.circuit_ref().name}{subcircuit.expanded_name()}"
+
+
+def netlist_to_networkx(
+    netlist: kdb.Netlist,
+    fully_connected: bool = False,
+    include_labels: bool = True,
+    only_most_complex: bool = False,
+) -> nx.Graph:
+    """Convert a KLayout DB `Netlist` to a networkx graph.
+
+    Args:
+        netlist: The KLayout DB `Netlist` to convert to a networkx `Graph`.
+        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
+            going through other elements (False).
+        include_labels: Whether to include labels in the graph connected to corresponding cells.
+        only_most_complex: Whether to plot only the circuit with most connections or not.
+            Helpful for not plotting subcircuits separately.
+
+    Returns:
+        A networkx `Graph` representing the connectivity of the `Netlist`.
+    """
+    G = nx.Graph()
+
+    top_circuits = list(
+        itertools.islice(netlist.each_circuit_top_down(), netlist.top_circuit_count())
+    )
+
+    if only_most_complex:
+        top_circuits = (max(top_circuits, key=lambda x: x.pin_count()),)
+
+    for circuit in top_circuits:
+        # first flatten components that won't be kept
+        for subcircuit in circuit.each_subcircuit():
+            if subcircuit.name in {"TODO"}:
+                circuit.flatten_subcircuit(subcircuit)
+
+        for net in circuit.each_net():
+            # Get subcircuit pins if they exist (hierarchical export from KLayout)
+            net_pins = [
+                _get_subcircuit_name(subcircuit_pin_ref.subcircuit())
+                for subcircuit_pin_ref in net.each_subcircuit_pin()
+            ]
+            # or use all pins (flat like from Cadence SPICE)
+            if not net_pins:
+                net_pins.extend(pin_ref.pin().name() for pin_ref in net.each_pin())
+
+            # Assumed lone net with only label info
+            if (
+                include_labels
+                and net.expanded_name()
+                and "," not in net.expanded_name()
+            ):
+                G.add_edges_from(zip(net_pins, [net.name] * len(net_pins)))
+
+            if fully_connected:
+                G.add_edges_from(itertools.combinations(net_pins, 2))
+            else:
+                G.add_edges_from(zip(net_pins[:-1], net_pins[1:]))
+    return G
+

--- a/gplugins/klayout/netlist_graph.py
+++ b/gplugins/klayout/netlist_graph.py
@@ -47,7 +47,6 @@ def netlist_to_networkx(
             next(c for c in top_circuits if c.name.casefold() == top_cell.casefold()),
         )
 
-    # unique_net_counter = Counter()
     all_used_nets = set()
     for circuit in top_circuits:
         for device in circuit.each_device():
@@ -77,11 +76,7 @@ def netlist_to_networkx(
             # Create NetworkX representation
             G.add_node(device_name, **parameters)
             for net in nets:
-                # unique_net_counter.update([net.expanded_name()])
-                # net_name = (
-                #     f"{net.expanded_name()}_{unique_net_counter[net.expanded_name()]}"
-                # )
-                net_name = f"{net.expanded_name()}"
+                net_name = net.expanded_name()
                 G.add_edge(device_name, net_name)
                 all_used_nets.add(net_name)
 
@@ -94,7 +89,7 @@ def netlist_to_networkx(
     return G
 
 
-def networkx_from_file(
+def networkx_from_spice(
     filepath: PathType,
     include_labels: bool = True,
     top_cell: str | None = None,

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -39,7 +39,7 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
 
     n_nodes: int = 0
     calibre_location_pattern: str = r"\$X=(-?\d+) \$Y=(-?\d+)"
-    integer_to_string_map: MutableMapping[int, str] = dict()
+    integer_to_string_map: MutableMapping[int, str] = {}
 
     @override
     def wants_subcircuit(self, name: str):

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -79,6 +79,7 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
         nets: Sequence[kdb.Net],
         parameters: dict[str, int | float | str],
     ):
+        # Handle non-'X' elements with standard KLayout processing
         if element != "X":
             # Other devices with standard KLayout
             return super().element(

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -112,8 +112,7 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
             device.set_parameter(
                 key,
                 (
-                    value
-                    if not isinstance(value, str)
-                    else CalibreSpiceReader.hash_str_to_int(value)
+                    CalibreSpiceReader.hash_str_to_int(value) if isinstance(value, str) else value
+
                 ),
             )

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -113,7 +113,8 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
             device.set_parameter(
                 key,
                 (
-                    CalibreSpiceReader.hash_str_to_int(value) if isinstance(value, str) else value
-
+                    CalibreSpiceReader.hash_str_to_int(value)
+                    if isinstance(value, str)
+                    else value
                 ),
             )

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -1,7 +1,7 @@
-from abc import ABC, abstractmethod
 import hashlib
 import re
-from collections.abc import Mapping, MutableMapping, Sequence
+from abc import ABC, abstractmethod
+from collections.abc import MutableMapping, Sequence
 from typing import Any, override
 
 import klayout.db as kdb

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -8,7 +8,8 @@ import klayout.db as kdb
 class CalibreSpiceReader(kdb.NetlistSpiceReaderDelegate):
     """KLayout Spice reader for Calibre LVS extraction output.
 
-    Considers parameter values for generic `X` devices and ignores comments after $."""
+    Considers parameter values for generic `X` devices that start with `WG`.
+    Ignores comments after $ excluding location given with ``$X=number $Y=number``."""
 
     n_nodes: int = 0
     calibre_location_pattern: str = r"\$X=(-?\d+) \$Y=(-?\d+)"
@@ -27,7 +28,7 @@ class CalibreSpiceReader(kdb.NetlistSpiceReaderDelegate):
             if location_matches := re.search(self.calibre_location_pattern, s):
                 x_value, y_value = (int(e) / 1000 for e in location_matches.group(1, 2))
 
-            # Use default KLayout parser for rest pf the SPICE
+            # Use default KLayout parser for rest of the SPICE
             s, *_ = s.split("$")
 
         parsed = super().parse_element(s, element)
@@ -68,7 +69,7 @@ class CalibreSpiceReader(kdb.NetlistSpiceReaderDelegate):
                     self.string_to_integer_map[value] = hashed_value
                     self.integer_to_string_map[hashed_value] = value
 
-            for i, net in enumerate(nets):
+            for i in range(len(nets)):
                 clx.add_terminal(kdb.DeviceTerminalDefinition(str(i)))
             circuit.netlist().add(clx)
 

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -12,7 +12,7 @@ class NetlistSpiceReaderDelegateWithStrings(kdb.NetlistSpiceReaderDelegate, ABC)
 
     @property
     @abstractmethod
-    def integer_to_string_map(self) -> MutableMapping[str, int]:
+    def integer_to_string_map(self) -> MutableMapping[int, str]:
         pass
 
 

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -16,6 +16,21 @@ class NetlistSpiceReaderDelegateWithStrings(kdb.NetlistSpiceReaderDelegate, ABC)
         pass
 
 
+class NoCommentReader(kdb.NetlistSpiceReaderDelegate):
+    """KLayout Spice reader without comments after $. This allows checking the netlist for HSPICE."""
+
+    n_nodes: int = 0
+
+    def parse_element(self, s: str, element: str) -> kdb.ParseElementData:
+        if "$" in s:
+            s, *_ = s.split("$")  # Don't take comments into account
+        parsed = super().parse_element(s, element)
+        # ensure uniqueness
+        parsed.model_name = parsed.model_name + f"_{self.n_nodes}"
+        self.n_nodes += 1
+        return parsed
+
+
 class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
     """KLayout Spice reader for Calibre LVS extraction output.
 

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -24,7 +24,6 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
 
     n_nodes: int = 0
     calibre_location_pattern: str = r"\$X=(-?\d+) \$Y=(-?\d+)"
-    string_to_integer_map: MutableMapping[str, int] = dict()
     integer_to_string_map: MutableMapping[int, str] = dict()
 
     @override
@@ -79,7 +78,10 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
             for key, value in parameters.items():
                 clx.add_parameter(kdb.DeviceParameterDefinition(key))
                 # map string variables to integers
-                if isinstance(value, str) and value not in self.string_to_integer_map:
+                if (
+                    isinstance(value, str)
+                    and value not in self.integer_to_string_map.values()
+                ):
                     hashed_value = CalibreSpiceReader.hash_str_to_int(value)
                     self.integer_to_string_map[hashed_value] = value
 

--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -1,16 +1,82 @@
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, override
+
 import klayout.db as kdb
 
 
-class NoCommentReader(kdb.NetlistSpiceReaderDelegate):
-    """KLayout Spice reader without comments after $. This allows checking the netlist for HSPICE."""
+class CalibreSpiceReader(kdb.NetlistSpiceReaderDelegate):
+    """KLayout Spice reader for Calibre LVS extraction output.
+
+    Considers parameter values for generic `X` devices and ignores comments after $."""
 
     n_nodes: int = 0
+    calibre_location_pattern: str = r"\$X=(-?\d+) \$Y=(-?\d+)"
+    string_to_integer_map: Mapping[str, int] = dict()
+    integer_to_string_map: Mapping[int, str] = dict()
 
+    @override
+    def wants_subcircuit(self, name: str):
+        """Model all SPICE models that start with `WG` as devices in order to support parameters."""
+        return "WG" in name or super().wants_subcircuit(name)
+
+    @override
     def parse_element(self, s: str, element: str) -> kdb.ParseElementData:
+        x_value, y_value = None, None
         if "$" in s:
-            s, *_ = s.split("$")  # Don't take comments into account
+            if location_matches := re.search(self.calibre_location_pattern, s):
+                x_value, y_value = (int(e) / 1000 for e in location_matches.group(1, 2))
+
+            # Use default KLayout parser for rest pf the SPICE
+            s, *_ = s.split("$")
+
         parsed = super().parse_element(s, element)
+        parsed.parameters |= {"x": x_value, "y": y_value}
+
         # ensure uniqueness
-        parsed.model_name = parsed.model_name + f"_{self.n_nodes}"
+        # parsed.model_name = parsed.model_name + f"_{self.n_nodes}"
         self.n_nodes += 1
         return parsed
+
+    @override
+    def element(
+        self,
+        circuit: kdb.Circuit,
+        element: str,
+        name: str,
+        model: str,
+        value: Any,
+        nets: Sequence[kdb.Net],
+        parameters: Mapping[str, int | float | str],
+    ):
+        if element != "X":
+            # Other devices with standard KLayout
+            return super().element(
+                circuit, element, name, model, value, nets, parameters
+            )
+        clx = circuit.netlist().device_class_by_name(model)
+
+        # Create Device class on first occurrence
+        if not clx:
+            clx = kdb.DeviceClass()
+            clx.name = model
+            for key, value in parameters.items():
+                clx.add_parameter(kdb.DeviceParameterDefinition(key))
+                # map string variables to integers
+                if isinstance(value, str) and value not in self.string_to_integer_map:
+                    hashed_value = hash(value)
+                    self.string_to_integer_map[value] = hashed_value
+                    self.integer_to_string_map[hashed_value] = value
+
+            for i, net in enumerate(nets):
+                clx.add_terminal(kdb.DeviceTerminalDefinition(str(i)))
+            circuit.netlist().add(clx)
+
+        device = circuit.create_device(clx, name)
+        for i, net in enumerate(nets):
+            device.connect_terminal(i, net)
+
+        for key, value in parameters.items():
+            device.set_parameter(
+                key, value if not isinstance(value, str) else hash(value)
+            )

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -1,15 +1,11 @@
-import itertools
 from collections.abc import Collection
 from itertools import combinations
 from pathlib import Path
 
-import klayout.db as kdb
 import matplotlib.pyplot as plt
 import networkx as nx
-from gdsfactory.config import logger
 
-from gplugins.klayout.netlist_spice_reader import NoCommentReader
-from gplugins.klayout.netlist_graph import netlist_to_networkx, networkx_from_file
+from gplugins.klayout.netlist_graph import networkx_from_file
 
 
 def plot_nets(
@@ -35,9 +31,7 @@ def plot_nets(
             Helpful for reducing trivial waveguide elements.
     """
 
-    G_connectivity = networkx_from_file(
-        **locals()
-    )
+    G_connectivity = networkx_from_file(**locals())
 
     if nodes_to_reduce:
 

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -4,6 +4,7 @@ from itertools import combinations
 import matplotlib.pyplot as plt
 import networkx as nx
 from gdsfactory.typings import PathType
+from klayout.db import NetlistSpiceReaderDelegate
 
 from gplugins.klayout.netlist_graph import networkx_from_spice
 from gplugins.klayout.netlist_spice_reader import CalibreSpiceReader
@@ -15,6 +16,7 @@ def plot_nets(
     include_labels: bool = True,
     top_cell: str | None = None,
     nodes_to_reduce: Collection[str] | None = None,
+    spice_reader: type[NetlistSpiceReaderDelegate] = CalibreSpiceReader,
 ) -> None:
     """Plots the connectivity between the components in the KLayout LayoutToNetlist file from :func:`~get_l2n`.
 
@@ -26,6 +28,7 @@ def plot_nets(
         top_cell: The name of the top cell to consider for the NetworkX graph. Defaults to all top cells.
         nodes_to_reduce: Nodes to reduce to a single edge. Comparison made with Python ``in`` operator.
             Helpful for reducing trivial waveguide elements.
+        spice_reader: The KLayout Spice reader to use for parsing SPICE netlists.
     """
 
     G_connectivity = networkx_from_spice(**locals())

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -5,7 +5,8 @@ import matplotlib.pyplot as plt
 import networkx as nx
 from gdsfactory.typings import PathType
 
-from gplugins.klayout.netlist_graph import networkx_from_file
+from gplugins.klayout.netlist_graph import networkx_from_spice
+from gplugins.klayout.netlist_spice_reader import CalibreSpiceReader
 
 
 def plot_nets(
@@ -27,7 +28,7 @@ def plot_nets(
             Helpful for reducing trivial waveguide elements.
     """
 
-    G_connectivity = networkx_from_file(**locals())
+    G_connectivity = networkx_from_spice(**locals())
 
     if nodes_to_reduce:
 

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -10,7 +10,6 @@ from gplugins.klayout.netlist_graph import networkx_from_file
 
 def plot_nets(
     filepath: str | Path,
-    fully_connected: bool = False,
     interactive: bool = False,
     include_labels: bool = True,
     only_most_complex: bool = False,
@@ -21,10 +20,8 @@ def plot_nets(
     Args:
         filepath: Path to the KLayout LayoutToNetlist file or a SPICE netlist.
             File extensions should be `.l2n` and `.spice`, respectively.
-        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
-            going through other elements (False).
         interactive: Whether to plot an interactive graph with `pyvis` or not.
-        include_labels: Whether to include labels in the graph connected to corresponding cells.
+        include_labels: Whether to include net labels in the graph connected to corresponding cells.
         only_most_complex: Whether to plot only the circuit with most connections or not.
             Helpful for not plotting subcircuits separately.
         nodes_to_reduce: Nodes to reduce to a single edge. Comparison made with Python ``in`` operator.

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -1,6 +1,7 @@
 from collections.abc import Collection
 from itertools import combinations
 from pathlib import Path
+from gdsfactory.typings import PathType
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -9,10 +10,10 @@ from gplugins.klayout.netlist_graph import networkx_from_file
 
 
 def plot_nets(
-    filepath: str | Path,
+    filepath: PathType,
     interactive: bool = False,
     include_labels: bool = True,
-    only_most_complex: bool = False,
+    top_cell: str | None = None,
     nodes_to_reduce: Collection[str] | None = None,
 ) -> None:
     """Plots the connectivity between the components in the KLayout LayoutToNetlist file from :func:`~get_l2n`.
@@ -22,8 +23,7 @@ def plot_nets(
             File extensions should be `.l2n` and `.spice`, respectively.
         interactive: Whether to plot an interactive graph with `pyvis` or not.
         include_labels: Whether to include net labels in the graph connected to corresponding cells.
-        only_most_complex: Whether to plot only the circuit with most connections or not.
-            Helpful for not plotting subcircuits separately.
+        top_cell: The name of the top cell to consider for the NetworkX graph. Defaults to all top cells.
         nodes_to_reduce: Nodes to reduce to a single edge. Comparison made with Python ``in`` operator.
             Helpful for reducing trivial waveguide elements.
     """

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -9,70 +9,7 @@ import networkx as nx
 from gdsfactory.config import logger
 
 from gplugins.klayout.netlist_spice_reader import NoCommentReader
-
-
-def _get_subcircuit_name(subcircuit: kdb.SubCircuit) -> str:
-    """Get the _cell name_ of a `SubCircuit` instance"""
-    return f"{subcircuit.circuit_ref().name}{subcircuit.expanded_name()}"
-
-
-def netlist_to_networkx(
-    netlist: kdb.Netlist,
-    fully_connected: bool = False,
-    include_labels: bool = True,
-    only_most_complex: bool = False,
-) -> nx.Graph:
-    """Convert a KLayout DB `Netlist` to a networkx graph.
-
-    Args:
-        netlist: The KLayout DB `Netlist` to convert to a networkx `Graph`.
-        fully_connected: Whether to plot the graph as elements fully connected to all other ones (True) or
-            going through other elements (False).
-        include_labels: Whether to include labels in the graph connected to corresponding cells.
-        only_most_complex: Whether to plot only the circuit with most connections or not.
-            Helpful for not plotting subcircuits separately.
-
-    Returns:
-        A networkx `Graph` representing the connectivity of the `Netlist`.
-    """
-    G = nx.Graph()
-
-    top_circuits = list(
-        itertools.islice(netlist.each_circuit_top_down(), netlist.top_circuit_count())
-    )
-
-    if only_most_complex:
-        top_circuits = (max(top_circuits, key=lambda x: x.pin_count()),)
-
-    for circuit in top_circuits:
-        # first flatten components that won't be kept
-        for subcircuit in circuit.each_subcircuit():
-            if subcircuit.name in {"TODO"}:
-                circuit.flatten_subcircuit(subcircuit)
-
-        for net in circuit.each_net():
-            # Get subcircuit pins if they exist (hierarchical export from KLayout)
-            net_pins = [
-                _get_subcircuit_name(subcircuit_pin_ref.subcircuit())
-                for subcircuit_pin_ref in net.each_subcircuit_pin()
-            ]
-            # or use all pins (flat like from Cadence SPICE)
-            if not net_pins:
-                net_pins.extend(pin_ref.pin().name() for pin_ref in net.each_pin())
-
-            # Assumed lone net with only label info
-            if (
-                include_labels
-                and net.expanded_name()
-                and "," not in net.expanded_name()
-            ):
-                G.add_edges_from(zip(net_pins, [net.name] * len(net_pins)))
-
-            if fully_connected:
-                G.add_edges_from(itertools.combinations(net_pins, 2))
-            else:
-                G.add_edges_from(zip(net_pins[:-1], net_pins[1:]))
-    return G
+from gplugins.klayout.netlist_graph import netlist_to_networkx
 
 
 def plot_nets(

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -1,10 +1,9 @@
 from collections.abc import Collection
 from itertools import combinations
-from pathlib import Path
-from gdsfactory.typings import PathType
 
 import matplotlib.pyplot as plt
 import networkx as nx
+from gdsfactory.typings import PathType
 
 from gplugins.klayout.netlist_graph import networkx_from_file
 

--- a/gplugins/klayout/plot_nets.py
+++ b/gplugins/klayout/plot_nets.py
@@ -9,7 +9,7 @@ import networkx as nx
 from gdsfactory.config import logger
 
 from gplugins.klayout.netlist_spice_reader import NoCommentReader
-from gplugins.klayout.netlist_graph import netlist_to_networkx
+from gplugins.klayout.netlist_graph import netlist_to_networkx, networkx_from_file
 
 
 def plot_nets(
@@ -35,27 +35,8 @@ def plot_nets(
             Helpful for reducing trivial waveguide elements.
     """
 
-    match Path(filepath).suffix:
-        case ".l2n" | ".txt":
-            l2n = kdb.LayoutToNetlist()
-            l2n.read(str(filepath))
-            netlist = l2n.netlist()
-        case ".cir" | ".sp" | ".spi" | ".spice":
-            reader = kdb.NetlistSpiceReader(NoCommentReader())
-            netlist = kdb.Netlist()
-            netlist.read(str(filepath), reader)
-        case _:
-            logger.warning("Assuming file is KLayout native LayoutToNetlist file")
-            l2n = kdb.LayoutToNetlist()
-            l2n.read(str(filepath))
-            netlist = l2n.netlist()
-
-    # Creating a graph for the connectivity
-    G_connectivity = netlist_to_networkx(
-        netlist,
-        fully_connected=fully_connected,
-        include_labels=include_labels,
-        only_most_complex=only_most_complex,
+    G_connectivity = networkx_from_file(
+        **locals()
     )
 
     if nodes_to_reduce:

--- a/gplugins/klayout/tests/test_netlist_spice_reader.py
+++ b/gplugins/klayout/tests/test_netlist_spice_reader.py
@@ -7,7 +7,12 @@ from gplugins.klayout.netlist_spice_reader import CalibreSpiceReader
     "s,element,expected_name,expected_nets",
     [
         ("1 2 POS test_model", "X", "test_model", {"1", "2", "POS"}),
-        ("2 3 NEG test_model2 $ This is a comment", "X", "test_model2", {"2", "3", "NEG"}),
+        (
+            "2 3 NEG test_model2 $ This is a comment",
+            "X",
+            "test_model2",
+            {"2", "3", "NEG"},
+        ),
         (
             "5 4 some_elem some_variable=1 $ This is a comment",
             "X",

--- a/gplugins/klayout/tests/test_netlist_spice_reader.py
+++ b/gplugins/klayout/tests/test_netlist_spice_reader.py
@@ -1,25 +1,25 @@
 import pytest
 
-from gplugins.klayout.netlist_spice_reader import NoCommentReader
+from gplugins.klayout.netlist_spice_reader import CalibreSpiceReader
 
 
 @pytest.mark.parametrize(
     "s,element,expected_name,expected_nets",
     [
-        ("1 2 POS", "X", "POS_0", {"1", "2"}),
-        ("2 3 NEG $ This is a comment", "X", "NEG_0", {"2", "3"}),
+        ("1 2 POS test_model", "X", "test_model", {"1", "2", "POS"}),
+        ("2 3 NEG test_model2 $ This is a comment", "X", "test_model2", {"2", "3", "NEG"}),
         (
             "5 4 some_elem some_variable=1 $ This is a comment",
             "X",
-            "some_elem_0",
+            "some_elem",
             {"5", "4"},
         ),
     ],
 )
-def test_NoCommentReader(
+def test_CalibreSpiceReader(
     s: str, element: str, expected_name: str, expected_nets: set[str]
 ) -> None:
-    reader = NoCommentReader()
+    reader = CalibreSpiceReader()
     parsed = reader.parse_element(s, element)
     assert set(parsed.net_names) == expected_nets
     assert parsed.model_name == expected_name.upper()

--- a/gplugins/klayout/tests/test_plot_nets.py
+++ b/gplugins/klayout/tests/test_plot_nets.py
@@ -5,6 +5,7 @@ import pytest
 from gdsfactory.samples.demo.lvs import pads_correct
 
 from gplugins.klayout.get_netlist import get_l2n, get_netlist
+from gplugins.klayout.netlist_spice_reader import NoCommentReader
 from gplugins.klayout.plot_nets import plot_nets
 
 
@@ -32,6 +33,9 @@ def spice_netlist(tmpdir_factory) -> str:
     return netlist_path
 
 
+@pytest.mark.skip(
+    reason="Implementation changed to consider detected devices and current pads_correct example does not have any."
+)
 @pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.parametrize("include_labels", [True, False])
 @pytest.mark.parametrize(
@@ -48,6 +52,7 @@ def test_plot_nets(
         interactive=interactive,
         include_labels=include_labels,
         nodes_to_reduce=nodes_to_reduce,
+        spice_reader=NoCommentReader,
     )
     if interactive:
         assert Path("connectivity.html").exists()

--- a/gplugins/klayout/tests/test_plot_nets.py
+++ b/gplugins/klayout/tests/test_plot_nets.py
@@ -34,7 +34,6 @@ def spice_netlist(tmpdir_factory) -> str:
 
 @pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.parametrize("include_labels", [True, False])
-@pytest.mark.parametrize("only_most_complex", [True, False])
 @pytest.mark.parametrize(
     "nodes_to_reduce", [None, {"straight"}, {"straight", "bend_euler"}]
 )
@@ -42,14 +41,12 @@ def test_plot_nets(
     klayout_netlist,
     interactive,
     include_labels,
-    only_most_complex,
     nodes_to_reduce,
 ):
     plot_nets(
         klayout_netlist,
         interactive=interactive,
         include_labels=include_labels,
-        only_most_complex=only_most_complex,
         nodes_to_reduce=nodes_to_reduce,
     )
     if interactive:

--- a/gplugins/klayout/tests/test_plot_nets.py
+++ b/gplugins/klayout/tests/test_plot_nets.py
@@ -32,7 +32,6 @@ def spice_netlist(tmpdir_factory) -> str:
     return netlist_path
 
 
-@pytest.mark.parametrize("fully_connected", [True, False])
 @pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.parametrize("include_labels", [True, False])
 @pytest.mark.parametrize("only_most_complex", [True, False])
@@ -41,7 +40,6 @@ def spice_netlist(tmpdir_factory) -> str:
 )
 def test_plot_nets(
     klayout_netlist,
-    fully_connected,
     interactive,
     include_labels,
     only_most_complex,
@@ -49,7 +47,6 @@ def test_plot_nets(
 ):
     plot_nets(
         klayout_netlist,
-        fully_connected=fully_connected,
         interactive=interactive,
         include_labels=include_labels,
         only_most_complex=only_most_complex,


### PR DESCRIPTION
* Convert Calibre LVS netlist output to a NetworkX Graph through KLayout SPICE handling.
  * Parameter values included and visible in `plot_nets`