### PR TITLE
Strip brackets from model name in Calibre SPICE reader

### DIFF
--- a/gplugins/klayout/netlist_spice_reader.py
+++ b/gplugins/klayout/netlist_spice_reader.py
@@ -27,6 +27,7 @@ class NoCommentReader(kdb.NetlistSpiceReaderDelegate):
     def parse_element(self, s: str, element: str) -> kdb.ParseElementData:
         if "$" in s:
             s, *_ = s.split("$")  # Don't take comments into account
+
         parsed = super().parse_element(s, element)
         # ensure uniqueness
         parsed.model_name = parsed.model_name + f"_{self.n_nodes}"
@@ -52,6 +53,9 @@ class CalibreSpiceReader(NetlistSpiceReaderDelegateWithStrings):
 
     @override
     def parse_element(self, s: str, element: str) -> kdb.ParseElementData:
+        # Allow Calibre-style model name given as `$[model_name]` by removing the brackets
+        s = re.sub(r"\$\[([^\]]+)\]", r"\1", s)
+
         x_value, y_value = None, None
         if "$" in s:
             if location_matches := re.search(self.calibre_location_pattern, s):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,8 @@ lint.ignore = [
   "C408",  # C408 Unnecessary `dict` call (rewrite as a literal)
   "E402",  # module level import not at top of file
   "B018",  # found useless expression
-  "B028"  # no explicit stacklevel
+  "B028",  # no explicit stacklevel
+  "D301"  # allow escape sequences in docstrings
 ]
 lint.select = [
   "E",  # pycodestyle errors


### PR DESCRIPTION
A bit nicer output from Calibre SPICE netlists