### PR TITLE
Update meep_adjoint_optimization.py. component.copy() to component.dup()

### DIFF
--- a/gplugins/gmeep/meep_adjoint_optimization.py
+++ b/gplugins/gmeep/meep_adjoint_optimization.py
@@ -137,7 +137,7 @@ def get_meep_adjoint_optimizer(
         for monitor in monitors.values()
     ]
 
-    c = component.copy()
+    c = component.dup()
     for design_region, design_variable in zip(design_regions, design_variables):
         sim.geometry.append(
             Block(design_region.size, design_region.center, material=design_variable)


### PR DESCRIPTION
updating component.copy() to component.dup() to address warning: "UserWarning: copy() is deprecated and will be removed in gdsfactory9. Please use dup() instead."