### PR TITLE
update to latest gdsfactory

### DIFF
--- a/gplugins/common/base_models/component.py
+++ b/gplugins/common/base_models/component.py
@@ -1,10 +1,12 @@
 from functools import cached_property
 from hashlib import md5
+from typing import TypeAlias
 
 import gdsfactory as gf
 import numpy as np
 from gdsfactory.component import Component
 from gdsfactory.technology import LayerLevel, LayerStack
+from numpy.typing import NDArray
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -16,6 +18,23 @@ from shapely import MultiPolygon, Polygon
 from gplugins.gmsh.parse_gds import cleanup_component
 
 from ..types import AnyShapelyPolygon, GFComponent
+
+Coordinate: TypeAlias = tuple[float, float]
+
+
+def move_polar_rad_copy(
+    pos: Coordinate, angle: float, length: float
+) -> NDArray[np.float64]:
+    """Returns the points of a position (pos) with angle, shifted by length.
+
+    Args:
+        pos: position.
+        angle: in radians.
+        length: extension length in um.
+    """
+    c = np.cos(angle)
+    s = np.sin(angle)
+    return pos + length * np.array([c, s])
 
 
 class LayeredComponentBase(BaseModel):

--- a/gplugins/common/utils/add_simulation_markers.py
+++ b/gplugins/common/utils/add_simulation_markers.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import warnings
 
 import gdsfactory as gf
-import numpy as np
 from gdsfactory.add_pins import add_pin_rectangle
 from gdsfactory.component import Component
-from gdsfactory.components.bend_circular import bend_circular
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerLevel
 from gdsfactory.typings import ComponentSpec, Layer
@@ -16,7 +14,7 @@ from gdsfactory.typings import ComponentSpec, Layer
 
 @gf.cell
 def add_simulation_markers(
-    component: ComponentSpec = bend_circular,
+    component: ComponentSpec = gf.c.bend_circular,
     port_margin: float = 3,
     port_source_name: str = "o1",
     layer_source: Layer = (110, 0),
@@ -107,9 +105,7 @@ def add_simulation_markers(
 
     # Add source
     port = ref.ports[port_source_name]
-    angle_rad = np.radians(port.orientation)
-
-    port = port.move_polar_copy(angle=angle_rad, d=port_source_offset)
+    port = port.copy_polar(d=port_source_offset / c.kcl.dbu, angle=port.angle)
     add_pin_rectangle(c, port=port, port_margin=port_margin, layer=layer_source)
 
     layer_stack.layers["source"] = LayerLevel(
@@ -124,7 +120,7 @@ def add_simulation_markers(
 if __name__ == "__main__":
     # c = gf.components.coupler_ring()
     c = gf.components.mmi1x2()
-    c = add_simulation_markers(c)
+    # c = add_simulation_markers(c)
     c.show()
     scene = c.to_3d()
     scene.show()

--- a/gplugins/gmeep/get_simulation.py
+++ b/gplugins/gmeep/get_simulation.py
@@ -10,10 +10,10 @@ import gdsfactory as gf
 import meep as mp
 import numpy as np
 from gdsfactory.component import Component
-from gdsfactory.components.containers.extension import extend_ports, move_polar_rad_copy
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 
+from gplugins.common.base_models.component import move_polar_rad_copy
 from gplugins.gmeep.get_material import get_material
 from gplugins.gmeep.get_meep_geometry import (
     get_meep_geometry_from_component,
@@ -163,7 +163,9 @@ def get_simulation(
     ), f"component needs to be a gf.Component, got Type {type(component)}"
 
     component_extended = (
-        extend_ports(component=component, length=extend_ports_length, centered=True)
+        gf.c.extend_ports(
+            component=component, length=extend_ports_length, centered=True
+        )
         if extend_ports_length
         else component
     )

--- a/gplugins/gmeep/get_simulation.py
+++ b/gplugins/gmeep/get_simulation.py
@@ -10,7 +10,7 @@ import gdsfactory as gf
 import meep as mp
 import numpy as np
 from gdsfactory.component import Component
-from gdsfactory.components.extension import extend_ports, move_polar_rad_copy
+from gdsfactory.components.containers.extension import extend_ports, move_polar_rad_copy
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 
@@ -108,6 +108,7 @@ def get_simulation(
         wavelength_points: wavelength steps.
         dfcen: delta frequency.
         port_source_name: input port name.
+        port_source_mode: mode number for source.
         port_margin: margin on each side of the port.
         distance_source_to_monitors: in (um) source goes before.
         port_source_offset: offset between source GDS port and source MEEP port.

--- a/gplugins/klayout/drc/write_drc.py
+++ b/gplugins/klayout/drc/write_drc.py
@@ -138,6 +138,7 @@ def check_width(value: float | int, layer: str, angle_limit: float = 90.0) -> st
 
     Args:
         value: width in um if float, dbu if int (nm).
+        layer: layer name.
         angle_limit: angle limit in degrees.
     """
     category = "width"
@@ -153,6 +154,7 @@ def check_space(value: float | int, layer: str, angle_limit: float = 90.0) -> st
 
     Args:
         value: width in um if float, dbu if int (nm).
+        layer: layer name.
         angle_limit: angle limit in degrees.
     """
     category = "space"
@@ -198,7 +200,7 @@ def check_area(layer: str, min_area_um2: float | int = 2.0) -> str:
     """Return script for min area checking.
 
     Args:
-        layer1: layer name.
+        layer: layer name.
         min_area_um2: min area in um2. int if dbu, float if um.
 
     """
@@ -449,6 +451,12 @@ if __name__ == "__main__":
         derived_layer_boolean("TRENCH", "SLAB90", "-", "WG"),
         check_width(layer="WG", value=0.2),
         check_space(layer="WG", value=0.2),
+        check_width(layer="M1", value=0.2),
+        check_space(layer="M1", value=0.2),
+        check_width(layer="M2", value=1.0),
+        check_space(layer="M2", value=1.0),
+        check_width(layer="M3", value=1.0),
+        check_space(layer="M3", value=1.0),
         check_separation(layer1="HEATER", layer2="M1", value=1.0),
         check_enclosing(layer1="VIAC", layer2="M1", value=0.2),
         check_area(layer="WG", min_area_um2=0.05),

--- a/gplugins/tidy3d/get_simulation_grating_coupler.py
+++ b/gplugins/tidy3d/get_simulation_grating_coupler.py
@@ -13,12 +13,12 @@ import tidy3d as td
 from gdsfactory import logger
 from gdsfactory.add_padding import add_padding_container
 from gdsfactory.component import Component
-from gdsfactory.components.containers.extension import move_polar_rad_copy
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 from gdsfactory.typings import CrossSectionSpec
 from tidy3d.plugins.mode import ModeSolver
 
+from gplugins.common.base_models.component import move_polar_rad_copy
 from gplugins.tidy3d.materials import (
     get_index,
     get_medium,

--- a/gplugins/tidy3d/get_simulation_grating_coupler.py
+++ b/gplugins/tidy3d/get_simulation_grating_coupler.py
@@ -13,7 +13,7 @@ import tidy3d as td
 from gdsfactory import logger
 from gdsfactory.add_padding import add_padding_container
 from gdsfactory.component import Component
-from gdsfactory.components.extension import move_polar_rad_copy
+from gdsfactory.components.containers.extension import move_polar_rad_copy
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 from gdsfactory.typings import CrossSectionSpec
@@ -138,8 +138,8 @@ def get_simulation_grating_coupler(
         ymargin_bot: bottom distance from component to PML.
         zmargin: thickness for cladding above and below core.
         clad_material: material for cladding.
-        box_material:
-        substrate_material:
+        box_material: material for box.
+        substrate_material: material for substrate.
         box_thickness: (um).
         substrate_thickness: (um).
         port_waveguide_name: input port name.
@@ -180,11 +180,13 @@ def get_simulation_grating_coupler(
             Angle of the sidewall.
             ``sidewall_angle=0`` (default) specifies vertical wall,
             while ``0<sidewall_angle_deg<90`` for the base to be larger than the top.
+        padding_layer: layer to use for padding.
         dilation: float = 0.0
             Dilation of the polygon in the base by shifting each edge along its
             normal outwards direction by a distance;
             a negative value corresponds to erosion.
         cross_section: optional cross_section to extend ports beyond PML.
+        kwargs: Additional keyword arguments to pass to the Simulation constructor.
 
     Keyword Args:
         symmetry: Define Symmetries.


### PR DESCRIPTION
## Summary by Sourcery

Update design rule check (DRC) with new layers and checks for M1, M2, and M3.  Document parameters for `clad_material`, `box_material`, and `substrate_material` in `get_simulation_grating_coupler`. Add `padding_layer` parameter to `get_simulation_grating_coupler`. Add `port_source_mode` parameter to `get_simulation`.

Documentation:
- Document parameters for clad_material, box_material, and substrate_material in get_simulation_grating_coupler
- Add padding_layer parameter to get_simulation_grating_coupler
- Add port_source_mode parameter to get_simulation