### PR TITLE
remove broken code from docs

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -44,11 +44,7 @@ parts:
       - file: plugins_circuits
         sections:
           - file: notebooks/sax_01_sax
-          - file: notebooks/lumerical_2_interconnect
           - file: notebooks/vlsir_netlist
-      - file: sdl
-        sections:
-        - file: notebooks/21_schematic_driven_layout_lumerical
   - caption: Verification
     chapters:
       - file: notebooks/klayout_dataprep


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove the broken tutorials for lumerical and schematic-driven layout from the documentation