### PR TITLE
Fix tidy3d holes

### DIFF
--- a/gplugins/common/base_models/component.py
+++ b/gplugins/common/base_models/component.py
@@ -248,4 +248,3 @@ class LayeredComponentBase(BaseModel):
     def get_layer_center(self, layername: str) -> tuple[float, float, float]:
         bbox = self.get_layer_bbox(layername)
         return tuple(np.mean(bbox, axis=0))
-

--- a/gplugins/common/base_models/component.py
+++ b/gplugins/common/base_models/component.py
@@ -249,13 +249,3 @@ class LayeredComponentBase(BaseModel):
         bbox = self.get_layer_bbox(layername)
         return tuple(np.mean(bbox, axis=0))
 
-    def get_vertices(self, layer_name: str, buffer: float = 0.0):
-        poly = self.polygons[layer_name].buffer(buffer, join_style="mitre")
-        match poly:
-            case MultiPolygon():
-                verts = tuple(tuple(p.exterior.coords) for p in poly.geoms)
-            case Polygon():
-                verts = (tuple(poly.exterior.coords),)
-            case _:
-                raise TypeError(f"Invalid polygon type: {type(poly)}")
-        return verts

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -29,6 +29,7 @@ from gdsfactory.technology import LayerStack
 from pydantic import NonNegativeFloat
 from tidy3d.components.types import Symmetry
 from tidy3d.plugins.smatrix import ComponentModeler, Port
+from tidy3d.components.geometry.base import from_shapely
 
 from gplugins.common.base_models.component import LayeredComponentBase
 from gplugins.tidy3d.get_results import _executor
@@ -80,7 +81,7 @@ class Tidy3DComponent(LayeredComponentBase):
     reference_plane: Literal["bottom", "middle", "top"] = "middle"
 
     @cached_property
-    def polyslabs(self) -> dict[str, tuple[td.PolySlab, ...]]:
+    def polyslabs(self) -> dict[str, tuple[td.Geometry, ...]]:
         """Returns a dictionary of PolySlab instances for each layer in the component.
 
         Returns:
@@ -88,20 +89,18 @@ class Tidy3DComponent(LayeredComponentBase):
         """
         slabs = {}
         layers = sort_layers(self.geometry_layers, sort_by="mesh_order", reverse=True)
-
         for name, layer in layers.items():
             bbox = self.get_layer_bbox(name)
-            slabs[name] = tuple(
-                td.PolySlab(
-                    vertices=v,
-                    axis=2,
-                    slab_bounds=(bbox[0][2], bbox[1][2]),
-                    sidewall_angle=np.deg2rad(layer.sidewall_angle),
-                    reference_plane=self.reference_plane,
-                    dilation=self.dilation,
-                )
-                for v in self.get_vertices(name)
-            )
+            shape = self.polygons[name].buffer(distance=0.0, join_style="mitre")
+            geom = from_shapely(
+                        shape, 
+                        axis=2, 
+                        slab_bounds=(bbox[0][2], bbox[1][2]), 
+                        dilation=self.dilation, 
+                        sidewall_angle=np.deg2rad(layer.sidewall_angle), 
+                        reference_plane=self.reference_plane,
+                    )
+            slabs[name] = geom
 
         return slabs
 
@@ -366,24 +365,23 @@ class Tidy3DComponent(LayeredComponentBase):
         for name, layer in layers.items():
             if name not in self.polyslabs:
                 continue
-            polys = self.polyslabs[name]
+            poly = self.polyslabs[name]
 
-            for idx, poly in enumerate(polys):
-                axis, position = poly.parse_xyz_kwargs(x=x, y=y, z=z)
-                xlim, ylim = poly._get_plot_limits(axis=axis, buffer=0)
-                xmin, xmax = min(xmin, xlim[0]), max(xmax, xlim[1])
-                ymin, ymax = min(ymin, ylim[0]), max(ymax, ylim[1])
-                for shape in poly.intersections_plane(x=x, y=y, z=z):
-                    _shape = td.Geometry.evaluate_inf_shape(shape)
-                    patch = td.components.viz.polygon_patch(
-                        _shape,
-                        facecolor=colors[name],
-                        edgecolor="k",
-                        linewidth=0.5,
-                        label=name if idx == 0 else None,
-                        zorder=order_map[layer.mesh_order],
-                    )
-                    ax.add_artist(patch)
+            axis, position = poly.parse_xyz_kwargs(x=x, y=y, z=z)
+            xlim, ylim = poly._get_plot_limits(axis=axis, buffer=0)
+            xmin, xmax = min(xmin, xlim[0]), max(xmax, xlim[1])
+            ymin, ymax = min(ymin, ylim[0]), max(ymax, ylim[1])
+            for idx, shape in enumerate(poly.intersections_plane(x=x, y=y, z=z)):
+                _shape = td.Geometry.evaluate_inf_shape(shape)
+                patch = td.components.viz.polygon_patch(
+                    _shape,
+                    facecolor=colors[name],
+                    edgecolor="k",
+                    linewidth=0.5,
+                    label=name if idx == 0 else None,
+                    zorder=order_map[layer.mesh_order],
+                )
+                ax.add_artist(patch)
 
         size = list(self.size)
         cmin = list(self.bbox[0])

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -27,9 +27,9 @@ from gdsfactory.component import Component
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
 from pydantic import NonNegativeFloat
+from tidy3d.components.geometry.base import from_shapely
 from tidy3d.components.types import Symmetry
 from tidy3d.plugins.smatrix import ComponentModeler, Port
-from tidy3d.components.geometry.base import from_shapely
 
 from gplugins.common.base_models.component import LayeredComponentBase
 from gplugins.tidy3d.get_results import _executor
@@ -93,13 +93,13 @@ class Tidy3DComponent(LayeredComponentBase):
             bbox = self.get_layer_bbox(name)
             shape = self.polygons[name].buffer(distance=0.0, join_style="mitre")
             geom = from_shapely(
-                        shape, 
-                        axis=2, 
-                        slab_bounds=(bbox[0][2], bbox[1][2]), 
-                        dilation=self.dilation, 
-                        sidewall_angle=np.deg2rad(layer.sidewall_angle), 
-                        reference_plane=self.reference_plane,
-                    )
+                shape,
+                axis=2,
+                slab_bounds=(bbox[0][2], bbox[1][2]),
+                dilation=self.dilation,
+                sidewall_angle=np.deg2rad(layer.sidewall_angle),
+                reference_plane=self.reference_plane,
+            )
             slabs[name] = geom
 
         return slabs


### PR DESCRIPTION
properly removes holes from shapely shapes, such as rings

![image](https://github.com/user-attachments/assets/b935deaf-a9c4-4204-91a9-16f56f40c789)


fixes #565

## Summary by Sourcery

Improve handling of geometric shapes in Tidy3D component by removing holes and simplifying geometry processing

Bug Fixes:
- Fixed issue with polygon processing by using buffer method to remove holes and simplify shapes

Enhancements:
- Refactored polyslabs generation to use more robust geometry conversion
- Simplified plotting and geometry intersection logic

Chores:
- Removed redundant get_vertices method from base component class