### PR TITLE
simpler flow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,6 @@ jobs:
         env:
           SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
         run: |
-          make uv
           make install test-data
           uv run jb build docs
       - name: Upload artifact


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove unnecessary 'make uv' command from the GitHub Pages workflow