### PR TITLE
Update define_polysurfaces.py

### DIFF
--- a/gplugins/gmsh/define_polysurfaces.py
+++ b/gplugins/gmsh/define_polysurfaces.py
@@ -37,7 +37,7 @@ def define_polysurfaces(
                     origin=(0, 0, 0),
                 ),
                 model=model,
-                resolution=resolutions.get(layername, None),
+                resolutions=resolutions.get(layername, None),
                 mesh_order=layer_stack_.mesh_order,
                 physical_name=layer_physical_map[layername]
                 if layername in layer_physical_map


### PR DESCRIPTION
Polysurface class init keyword arg "resolution", should be "resolutions". Otherwise the error "TypeError: PolySurface.__init__() got an unexpected keyword argument 'resolution'. Did you mean 'resolutions'?" is thrown

## Summary by Sourcery

Bug Fixes:
- Correct the keyword argument from 'resolution' to 'resolutions' when initializing the PolySurface class to prevent a TypeError.