### PR TITLE
add padding_layers to write_sparameters_meep, meep geometry fix, get_port_layers fix in base_models

### DIFF
--- a/gplugins/common/base_models/component.py
+++ b/gplugins/common/base_models/component.py
@@ -19,6 +19,8 @@ from gplugins.gmsh.parse_gds import cleanup_component
 
 from ..types import AnyShapelyPolygon, GFComponent
 
+from gdsfactory.pdk import get_layer_stack, get_layer, get_layer_name
+
 Coordinate: TypeAlias = tuple[float, float]
 
 
@@ -223,13 +225,22 @@ class LayeredComponentBase(BaseModel):
         )
 
     def get_port_layers(self, port: gf.Port) -> tuple[str, ...]:
-        # FIXME: extract actual layer
-        # this needs to be a list of all layers and derived layers that are
-        # associated with the port layer enum
-        return ("core",)
-        return tuple(
-            k for k, v in self.layer_stack.layers.items() if port.layer in v.layer
-        )
+        layer_name = get_layer_name(port.layer)
+
+        derived_layers = []
+        for l_name, level in self.layer_stack.layers.items():
+            if layer_name in str(level.layer):
+                derived_layers.append(l_name)
+
+        return derived_layers
+
+
+
+
+        # return ("core",)
+        # return tuple(
+        #     k for k, v in self.layer_stack.layers.items() if port.layer in v.layer
+        # )
 
     def get_layer_bbox(
         self, layername: str

--- a/gplugins/gmeep/get_meep_geometry.py
+++ b/gplugins/gmeep/get_meep_geometry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import gdsfactory as gf
 import meep as mp
 import numpy as np
-from gdsfactory.pdk import get_layer_stack
+from gdsfactory.pdk import get_layer_stack, get_layer, get_layer_name
 from gdsfactory.technology import LayerStack
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
@@ -43,14 +43,18 @@ def get_meep_geometry_from_component(
     geometry = []
     layer_to_polygons = component_with_booleans.get_polygons_points()
 
-    ordered_layer_stack_keys = order_layer_stack(layer_stack)[::-1]
+    # ordered_layer_stack_keys = order_layer_stack(layer_stack)[::-1]
 
-    for layername in ordered_layer_stack_keys:
-        layer = layer_stack.layers[layername].layer
+    for layer_tuple in component_with_booleans.layers:
+        layer_index = get_layer(layer_tuple)
+        layer = get_layer_name(layer_index)
 
-        if layer not in layer_to_polygons:
-            continue
-        polygons = layer_to_polygons[layer]
+        # layer_material 
+
+        # if layer_index not in layer_to_polygons:
+        #     continue
+        polygons = layer_to_polygons[layer_index]
+
         print(f"layer: {layer}, polygons: {polygons}")
 
         if layer in layer_to_thickness and layer in layer_to_material:

--- a/gplugins/gmeep/write_sparameters_meep.py
+++ b/gplugins/gmeep/write_sparameters_meep.py
@@ -19,7 +19,7 @@ from gdsfactory.component import Component
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.serialization import clean_value_json
 from gdsfactory.technology import LayerStack
-from gdsfactory.typings import ComponentSpec, PathType, Port, PortSymmetries
+from gdsfactory.typings import ComponentSpec, PathType, Port, PortSymmetries, LayerSpec
 from tqdm.auto import tqdm
 
 from gplugins.common.utils import port_symmetries
@@ -151,6 +151,7 @@ def write_sparameters_meep(
     plot_args: dict | None = None,
     only_return_filepath_sim_settings=False,
     verbosity: int = 0,
+    padding_layers: tuple[LayerSpec, ...] = ("PADDING",),
     **settings,
 ) -> dict[str, np.ndarray]:
     r"""Returns Sparameters and writes them to npz filepath.
@@ -340,6 +341,7 @@ def write_sparameters_meep(
 
     component = gf.add_padding_container(
         component,
+        layers=padding_layers,
         default=0,
         top=ymargin_top,
         bottom=ymargin_bot,


### PR DESCRIPTION
Possible fix to the issue #575.
Possible workaround by modifying the function get_meep_geometry_from_component().
It seems to work with the tutorial notebook, but not sure if the results are correct. 
![meep_nb2](https://github.com/user-attachments/assets/561f82b5-8247-4d49-a279-39331db6d69b)
![meep_nb1](https://github.com/user-attachments/assets/4352b5ff-3a12-4640-8a1c-c0af5e6604b4)

## Summary by Sourcery

Add a padding_layers parameter to write_sparameters_meep and overhaul the layer iteration in get_meep_geometry_from_component to ensure accurate Meep geometry generation.

New Features:
- Allow specifying padding_layers in write_sparameters_meep for custom padding control

Bug Fixes:
- Fix get_meep_geometry_from_component to correctly iterate and extract layer geometries