### PR TITLE
fix_mypy

### DIFF
--- a/gplugins/common/utils/get_sparameters_path.py
+++ b/gplugins/common/utils/get_sparameters_path.py
@@ -70,7 +70,8 @@ def _get_sparameters_data(**kwargs: Any) -> np.ndarray[Any, Any]:
 
     """
     filepath = _get_sparameters_path(**kwargs)
-    return np.load(filepath)
+    data = np.load(filepath)
+    return np.array(data)
 
 
 get_sparameters_path_meow = partial(_get_sparameters_path, tool="meow")

--- a/gplugins/common/utils/get_sparameters_path.py
+++ b/gplugins/common/utils/get_sparameters_path.py
@@ -4,6 +4,7 @@ import hashlib
 import pathlib
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 import gdsfactory as gf
 import numpy as np
@@ -12,7 +13,7 @@ from gdsfactory.name import clean_value
 from gdsfactory.typings import ComponentSpec, PathType
 
 
-def get_kwargs_hash(**kwargs) -> str:
+def get_kwargs_hash(**kwargs: Any) -> str:
     """Returns kwargs parameters hash."""
     kwargs_list = [f"{key}={clean_value(kwargs[key])}" for key in sorted(kwargs.keys())]
     kwargs_string = "_".join(kwargs_list)
@@ -29,7 +30,7 @@ def get_component_hash(component: gf.Component) -> str:
 def _get_sparameters_path(
     component: ComponentSpec,
     dirpath: PathType | None = PATH.sparameters,
-    **kwargs,
+    **kwargs: Any,
 ) -> Path:
     """Return Sparameters npz filepath hashing simulation settings for a consistent unique name.
 
@@ -59,7 +60,7 @@ def _get_sparameters_path(
     return dirpath / f"{component.name}_{simulation_hash}.npz"
 
 
-def _get_sparameters_data(**kwargs) -> np.ndarray:
+def _get_sparameters_data(**kwargs: Any) -> np.ndarray[Any, Any]:
     """Returns Sparameters data in a pandas DataFrame.
 
     Keyword Args:

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import uuid
 from typing import Any
 
 import gdsfactory as gf
 import kfactory as kf
+import klayout.db as kdb
 from gdsfactory.component import GDSDIR_TEMP
 from gdsfactory.typings import PathType
-from kfactory import kdb
 
 
 def size(region: kdb.Region, offset: float, dbu=1e3) -> kdb.Region:
@@ -24,7 +26,7 @@ def copy(region: kdb.Region) -> kdb.Region:
     return region.dup()
 
 
-def _is_layer(value: any) -> bool:
+def _is_layer(value: Any) -> bool:
     try:
         layer, datatype = value
     except Exception:
@@ -32,21 +34,21 @@ def _is_layer(value: any) -> bool:
     return isinstance(layer, int) and isinstance(datatype, int)
 
 
-def _assert_is_layer(value: any) -> None:
+def _assert_is_layer(value: Any) -> None:
     if not _is_layer(value):
         raise ValueError(f"Layer must be a tuple of two integers. Got {value!r}")
 
 
 class Region(kdb.Region):
-    def __iadd__(self, offset) -> kdb.Region:
+    def __iadd__(self, offset: float | int) -> Region:
         """Adds an offset to the layer."""
         return size(self, offset)
 
-    def __isub__(self, offset) -> kdb.Region:
+    def __isub__(self, offset: float | int) -> Region:
         """Adds an offset to the layer."""
         return size(self, -offset)
 
-    def __add__(self, element) -> kdb.Region:
+    def __add__(self, element: float | int | kdb.Region) -> Region:
         """Adds an element to the region."""
         if isinstance(element, float | int):
             return size(self, element)
@@ -56,15 +58,17 @@ class Region(kdb.Region):
         else:
             raise ValueError(f"Cannot add type {type(element)} to region")
 
-    def __sub__(self, element: float | int | kdb.Region) -> kdb.Region | None:
+    def __sub__(self, element: float | int | kdb.Region) -> Region:
         """Subtracts an element from the region."""
         if isinstance(element, float | int):
             return size(self, -element)
 
         elif isinstance(element, kdb.Region):
             return boolean_not(self, element)
+        else:
+            raise ValueError(f"Cannot subtract type {type(element)} from region")
 
-    def copy(self) -> kdb.Region:
+    def copy(self) -> Region:
         return self.dup()
 
 

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -10,7 +10,7 @@ from gdsfactory.component import GDSDIR_TEMP
 from gdsfactory.typings import PathType
 
 
-def size(region: kdb.Region, offset: float, dbu=1e3) -> kdb.Region:
+def size(region: kdb.Region, offset: float, dbu: float = 1e3) -> kdb.Region:
     return region.dup().size(int(offset * dbu))
 
 

--- a/gplugins/klayout/drc/count_drc.py
+++ b/gplugins/klayout/drc/count_drc.py
@@ -19,7 +19,7 @@ def count_drc(rdb_path: PathType, threshold: int = 0) -> dict[str, int]:
         threshold: Minimum number of errors to be included in the output.
     """
     rdb_path = pathlib.Path(rdb_path)
-    errors_dict = {}
+    errors_dict: dict[str, int] = {}
 
     if not rdb_path.exists():
         raise FileNotFoundError(f"Cannot find {rdb_path}")
@@ -27,14 +27,17 @@ def count_drc(rdb_path: PathType, threshold: int = 0) -> dict[str, int]:
     if not rdb_path.is_dir():
         return _get_errors(rdb_path, threshold, errors_dict)
     for rdb_file in rdb_path.glob("*.rdb"):
-        errors_dict[rdb_file.stem] = count_drc(rdb_file)
+        sub_result = count_drc(rdb_file, threshold)
+        errors_dict.update(sub_result)
 
     return errors_dict
 
 
-def _get_errors(rdb_path, threshold, errors_dict):
-    r = rdb.ReportDatabase()
-    r.load(rdb_path)
+def _get_errors(
+    rdb_path: PathType, threshold: int, errors_dict: dict[str, int]
+) -> dict[str, int]:
+    r = rdb.ReportDatabase("name")
+    r.load(str(rdb_path))
 
     categories = {cat.rdb_id(): cat for cat in r.each_category()}
 
@@ -72,7 +75,7 @@ def plot_drc(errors: dict[str, int]) -> None:
     Args:
         errors: Dict of error names to number of errors.
     """
-    plt.bar(errors.keys(), errors.values())
+    plt.bar(list(errors.keys()), list(errors.values()))
     plt.title("DRC Errors")
     plt.xlabel("Categories")
     plt.ylabel("Error count")

--- a/gplugins/sax/interpolators.py
+++ b/gplugins/sax/interpolators.py
@@ -1,28 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
 import jax
 import jax.numpy as jnp
 
 
-def nd_interpolation(_grid, output_vector):
+def nd_interpolation(
+    _grid: list[jnp.ndarray], output_vector: jnp.ndarray
+) -> Callable[[jnp.ndarray], jnp.ndarray]:
     """Return JAX N-D interpolator given a M-D input and 1-D output vector."""
     _data = jnp.asarray(output_vector).reshape(len(_grid[i]) for i in range(len(_grid)))
 
     # @jax.jit
-    def _get_coordinate(arr1d: jnp.ndarray, value: jnp.ndarray):
+    def _get_coordinate(arr1d: jnp.ndarray, value: jnp.ndarray) -> jnp.ndarray:
         return jnp.interp(value, arr1d, jnp.arange(arr1d.shape[0]))
 
     # @jax.jit
-    def _get_coordinates(arrs1d: list[jnp.ndarray], values: jnp.ndarray):
+    def _get_coordinates(arrs1d: list[jnp.ndarray], values: jnp.ndarray) -> jnp.ndarray:
         return jnp.array([_get_coordinate(a, v) for a, v in zip(arrs1d, values)])
 
     # @jax.jit
-    def interp_output(params):
+    def interp_output(params: jnp.ndarray) -> jnp.ndarray:
         coords = _get_coordinates(_grid, params)
         return jax.scipy.ndimage.map_coordinates(_data, coords, 1, mode="nearest")
 
     return interp_output
 
 
-def nd_nd_interpolation(input_vectors, output_vectors):
+def nd_nd_interpolation(
+    input_vectors: jnp.ndarray, output_vectors: jnp.ndarray
+) -> list[Callable[[jnp.ndarray], jnp.ndarray]]:
     """Return JAX N-D interpolator given a N-D input and M-D output vector."""
     _grid = [jnp.sort(jnp.unique(input_vector)) for input_vector in input_vectors.T]
     return [

--- a/gplugins/sax/tests/test_mzi.py
+++ b/gplugins/sax/tests/test_mzi.py
@@ -7,12 +7,12 @@ import jax.numpy as jnp
 import sax
 
 
-def straight(wl=1.5, length=10.0, neff=2.4) -> sax.SDict:
+def straight(wl: float = 1.5, length: float = 10.0, neff: float = 2.4) -> sax.SDict:
     """Straight model."""
     return sax.reciprocal({("o1", "o2"): jnp.exp(2j * jnp.pi * neff * length / wl)})
 
 
-def mmi1x2():
+def mmi1x2() -> sax.SDict:
     """Assumes a perfect 1x2 splitter."""
     return sax.reciprocal(
         {
@@ -22,7 +22,7 @@ def mmi1x2():
     )
 
 
-def bend_euler(wl=1.5, length=20.0):
+def bend_euler(wl: float = 1.5, length: float = 20.0) -> sax.SDict:
     """Assumes reduced transmission for the euler bend compared to a straight."""
     return {k: 0.99 * v for k, v in straight(wl=wl, length=length).items()}
 
@@ -34,9 +34,9 @@ models = {
 }
 
 
-def module(S) -> None:
+def module(S: sax.SDict) -> None:
     for k, v in S.items():
-        S[k] = np.abs(v) ** 2
+        S[k] = jnp.abs(v) ** 2
 
 
 if __name__ == "__main__":

--- a/gplugins/sax/tests/test_mzi_lattice.py
+++ b/gplugins/sax/tests/test_mzi_lattice.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 import jax.numpy as jnp
 import numpy as np
@@ -35,7 +37,7 @@ def mmi1x2() -> sax.SDict:
     )
 
 
-def bend_euler(wl=1.5, length=20.0):
+def bend_euler(wl: float = 1.5, length: float = 20.0) -> sax.SDict:
     """Assumes reduced transmission for the euler bend compared to a straight."""
     return {k: 0.99 * v for k, v in straight(wl=wl, length=length).items()}
 
@@ -47,14 +49,14 @@ models = {
 }
 
 
-def module(S) -> list[float]:
+def module(S: sax.SDict) -> sax.SDict:
     """Rounds to 3 decimals and converts numpy to lists for serialization."""
     for k, v in S.items():
         S[k] = [float(i) for i in np.round(np.abs(v) ** 2, 3)]
     return S
 
 
-def test_mzi_lattice(data_regression, check: bool = True) -> None:
+def test_mzi_lattice(data_regression: Any, check: bool = True) -> None:
     c = mzis()
     netlist = c.get_netlist(recursive=True)
     circuit, _ = sax.circuit(netlist=netlist, models=models)
@@ -63,7 +65,7 @@ def test_mzi_lattice(data_regression, check: bool = True) -> None:
     S = circuit(wl=wl)
     S = module(S)
     if check:
-        d = dict(S21=S["o1", "o2"], S11=S["o1", "o1"])
+        d = dict(S21=S[("o1", "o2")], S11=S[("o1", "o1")])
         data_regression.check(d)
 
 
@@ -76,7 +78,7 @@ if __name__ == "__main__":
     wl = np.linspace(1.5, 1.6, 3)
     S = circuit(wl=wl)
     S = module(S)
-    d = dict(S21=S["o1", "o2"], S11=S["o1", "o1"])
+    d = dict(S21=S[("o1", "o2")], S11=S[("o1", "o1")])
 
     # import matplotlib.pyplot as plt
 

--- a/gplugins/tidy3d/materials.py
+++ b/gplugins/tidy3d/materials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import TypeAlias
 
 import tidy3d as td
 from tidy3d.components.medium import PoleResidue
@@ -12,7 +13,7 @@ material_name_to_tidy3d = {
     "sin": td.material_library["Si3N4"]["Luke2015PMLStable"],
 }
 
-MaterialSpecTidy3d = (
+MaterialSpecTidy3d: TypeAlias = (
     float
     | int
     | str
@@ -54,13 +55,13 @@ def get_index(
         spec=spec,
     )
     n, _ = td.Medium.eps_complex_to_nk(eps_complex)
-    return n
+    return float(n)
 
 
 def get_nk(
     spec: MaterialSpecTidy3d,
     wavelength: float = 1.55,
-) -> float:
+) -> tuple[float, float]:
     """Return refractive index and optical extinction coefficient from material database.
 
     Args:
@@ -85,11 +86,11 @@ def get_medium(spec: MaterialSpecTidy3d) -> td.Medium:
         return td.Medium(permittivity=spec**2)
     elif isinstance(spec, td.Medium | td.Medium2D | td.CustomMedium):
         return spec
-    elif spec in material_name_to_tidy3d:
+    elif isinstance(spec, str) and spec in material_name_to_tidy3d:
         return material_name_to_tidy3d[spec]
     elif isinstance(spec, PoleResidue):
         return spec
-    elif spec in td.material_library:
+    elif isinstance(spec, str) and spec in td.material_library:
         variants = td.material_library[spec].variants
         if len(variants) == 1:
             return list(variants.values())[0].medium

--- a/gplugins/tidy3d/types.py
+++ b/gplugins/tidy3d/types.py
@@ -7,7 +7,7 @@ from pydantic.functional_validators import AfterValidator
 
 
 # Function to validate the medium
-def validate_medium(v):
+def validate_medium(v: Any) -> td.AbstractMedium:
     # Check if the input is an instance of td.Medium
     assert isinstance(v, td.AbstractMedium), (
         f"Input should be a tidy3d medium, but got {type(v)} instead"
@@ -15,7 +15,7 @@ def validate_medium(v):
     return v
 
 
-Sparameters = dict[str, np.ndarray]
+Sparameters = dict[str, np.ndarray[Any, Any]]
 
 # Annotated type for Tidy3D medium with validation and serialization
 Tidy3DMedium = Annotated[


### PR DESCRIPTION
- fix mypy issues

Before: Found 512 errors in 48 files (checked 74 source files)


After this PR: 461 errors

## Summary by Sourcery

Fix various MyPy type errors by adding comprehensive type annotations across multiple modules and resolve runtime issues in DRC counting and plotting functions.

Bug Fixes:
- Merge recursive DRC counts correctly and propagate the threshold parameter in count_drc
- Instantiate and load ReportDatabase with the correct signature and string path argument
- Convert keys and values to lists when calling plt.bar to avoid sequence type errors
- Coerce get_index’s complex-to-n conversion to a float

Enhancements:
- Add detailed parameter and return type annotations in MLP regression, N-D interpolators, S-parameter utilities, and material handling functions
- Enable forward reference typing with __future__ annotations and collections.abc.Callable imports
- Introduce TypeAlias and refine np.ndarray and dict type aliases for Sparameters and MaterialSpecTidy3d