### PR TITLE
Run pre-commit hooks only on the diff for PRs

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
       - uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -12,7 +12,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: pip install pre-commit
+      - name: Set base and target commit SHA
+        if: github.event_name == 'pull_request'
+        id: commit-shas
+        run: |
+          echo "BASE=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          echo "TARGET=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+      - name: Run pre-commit hooks on diff files
+        if: github.event_name == 'pull_request'
+        run: |
+          pre-commit run --show-diff-on-failure --color=always \
+            --from-ref ${{ steps.commit-shas.outputs.BASE }} \
+            --to-ref ${{ steps.commit-shas.outputs.TARGET }}
       - uses: pre-commit/action@v3.0.1
+        if: github.event_name != 'pull_request'
 
   test_code:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Run for all files in other events

## Summary by Sourcery

Optimize the GitHub Actions workflow to cache pre-commit environments and limit hook execution to diff files on pull requests while preserving the full run on other events

CI:
- Add caching for pre-commit environments in the test_code workflow
- Install pre-commit and capture base/target SHAs for PR events
- Run pre-commit hooks only on changed files in pull requests
- Use full pre-commit/action run for non-PR events