### PR TITLE
Fixed/updated edgeports in gmsh plugin

### DIFF
--- a/gplugins/gmsh/xyz_mesh.py
+++ b/gplugins/gmsh/xyz_mesh.py
@@ -29,11 +29,10 @@ def define_edgeport(
     port: gf.Port,
     port_dict: dict[str, Any],
     model: Model,
-    layerlevel: LayerLevel,
 ):
     """Creates an unmeshed box at the port location to tag the edge port surfaces in the final mesh."""
-    zmin = port_dict.get("zmin") or layerlevel.zmin
-    zmax = port_dict.get("zmax") or zmin + layerlevel.thickness
+    zmin = port_dict.get("zmin")
+    zmax = port_dict.get("zmax")
 
     dz = zmax - zmin
     x, y = port.center
@@ -288,18 +287,16 @@ def xyz_mesh(
     # Add edgeports
     if edge_ports is not None:
         ports = component.ports
-        port_layernames = layer_stack.get_layer_to_layername()
-        for portname, edge_ports_dict in edge_ports:
+        for portname, edge_ports_dict in edge_ports.items():
             port = ports[portname]
             prisms_list.append(
                 define_edgeport(
                     port,
                     edge_ports_dict,
                     model,
-                    layerlevel=layer_stack.layers[port_layernames[port.layer][0]],
+
                 )
             )
-
     import copy
 
     resolutions = copy.deepcopy(resolutions)


### PR DESCRIPTION
Minor changes (or API updates) to ensure that edgeports can be generated correctly

```
    edge_ports = {
        "port_left": {
            "physical_name": "waveport_left",
            "width_pad": width_pad,     
            "zmin": zmin,
            "zmax": zmax,
            "resolution": {"resolution": 0.1},
        },
        "port_right": {
            "physical_name": "waveport_right",
            "width_pad": width_pad,     
            "zmin": zmin,
            "zmax": zmax,
            "resolution": {"resolution": 0.1},
        },
    }

    # Gmsh
    mesh = get_mesh(
        component=my_microstrip_component.copy(),
        type="3D",
        layer_stack=fr4_layer_stack,
        filename="straight_microstrip.msh",
        default_characteristic_length=500,
        port_names=["port_left", "port_right"],
        edge_ports=edge_ports,  # Pass the generated edge_ports
    )
```
![edgeports](https://github.com/user-attachments/assets/e42d22e8-937d-48f4-8605-79512980ca3e)

## Summary by Sourcery

Fix edge port generation in the Gmsh plugin by updating the define_edgeport API, requiring explicit zmin/zmax values, and correcting the edge_ports iteration in the xyz_mesh function.

Bug Fixes:
- Iterate over edge_ports using edge_ports.items() to properly retrieve port names and definitions.
- Eliminate references to layerlevel and port_layernames when calling define_edgeport to resolve port tagging errors.

Enhancements:
- Remove the layerlevel parameter from define_edgeport and simplify its signature.
- Require explicit zmin and zmax values instead of defaulting from layerlevel.