### PR TITLE
sax plot_model: better log scaling, better labelling

### DIFF
--- a/gplugins/sax/plot_model.py
+++ b/gplugins/sax/plot_model.py
@@ -14,6 +14,7 @@ def plot_model(
     port1: str = "o1",
     ports2: tuple[str, ...] | None = None,
     logscale: bool = True,
+    min_db_range: float = 0.5,
     fig=None,
     wavelength_start: float = 1.5,
     wavelength_stop: float = 1.6,
@@ -28,9 +29,10 @@ def plot_model(
         port1: input port name.
         ports2: list of ports.
         logscale: plots in dB logarithmic scale.
+        min_db_range: minimum dB range. Set to 0 to disable.
         fig: matplotlib figure.
-        wavelength_start: wavelength min (um).
-        wavelength_stop: wavelength max (um).
+        wavelength_start: wavelength min (µm).
+        wavelength_stop: wavelength max (µm).
         wavelength_points: number of wavelength steps.
         phase: plot phase instead of magnitude.
         title: plot title.
@@ -68,10 +70,15 @@ def plot_model(
                 y = np.abs(sdict[(port1, port2)])
                 y = 20 * np.log10(y) if logscale else y
                 ylabel = "|S (dB)|" if logscale else "|S|"
-            ax.plot(wavelengths, y, label=port2)
+            ax.plot(wavelengths, y, label=f"{port1}→{port2}")
+
+    if logscale:
+        current_ylim = ax.get_ylim()
+        if current_ylim[1] - current_ylim[0] < min_db_range:
+            ax.set_ylim(y.mean() - min_db_range / 2, y.mean() + min_db_range / 2)
 
     ax.set_title(title or f"{model.__name__} S-Parameters")
-    ax.set_xlabel("wavelength (um)")
+    ax.set_xlabel("wavelength (µm)")
     ax.set_ylabel(ylabel)
     plt.legend()
     return ax


### PR DESCRIPTION
## Summary by Sourcery

Improve log scaling and labeling in plot_model by adding a minimum dB range control, enhancing trace labels, and updating unit notation

Enhancements:
- Introduce a new min_db_range parameter to enforce a minimum y-axis range for dB-scaled plots
- Label S-parameter traces with port1→port2 notation
- Auto-adjust plot y-limits when the dynamic range is below the specified threshold

Documentation:
- Standardize unit notation from "um" to "µm" in docstrings and axis labels