### PR TITLE
Add minimal Copilot Setup Steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,10 @@
+name: Copilot Setup Steps
+on:
+  workflow_dispatch:
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+      - run: make install


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow for Copilot setup steps.

- Adds  with basic configuration.

No changes to existing code or tests.

## Summary by Sourcery

CI:
- Introduce a manual ‘Copilot Setup Steps’ workflow that checks out the repo, sets up UV, and runs ‘make install’