### PR TITLE
Upload, but not run, simulation for write_sparameters routine

### DIFF
--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -280,7 +280,7 @@ class Tidy3DComponent(LayeredComponentBase):
 
         cz = np.round(cz, abs(int(np.log10(grid_eps)))).item()
 
-        freqs = td.C_0 / np.linspace(
+        freqs = td.constants.C_0 / np.linspace(
             wavelength - bandwidth / 2, wavelength + bandwidth / 2, num_freqs
         )
 


### PR DESCRIPTION
In the `write_sparameters` routine, a simulation is created and automatically deployed/run on tidy servers. I think it is much safer to have an option to upload the simulation only, then let the user go into the Tidy Website GUI and inspect the simulation by hand to see if things make sense, then let the user run the simulation from the Tidy GUI. I also added a 'birdseye' monitor that spans the XY domain of the simulation and slices through the middle of the "core" of the component of interest in Z. 

Todo: In doing this, I had to comment out the part where the s parameters are returned, this needs to be fixed, otherwise `write_sparameters` does not return anything except for the whether or not the `upload` was successful.

## Summary by Sourcery

Change write_sparameters to upload a visualization-focused simulation to Tidy3D without running it, returning the uploaded task handle instead of local S-parameter results.

New Features:
- Add a birdseye field monitor spanning the XY domain through the core layer to aid visual inspection of simulations in the Tidy3D GUI.

Enhancements:
- Modify write_sparameters to create a copy of the simulation with plotting sources and monitors, and upload it to Tidy3D servers instead of running locally and saving S-parameters.