### PR TITLE
Remove matthew from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @MatthewMckee4
+* @joamatab


### PR DESCRIPTION
Since I'm leaving

## Summary by Sourcery

Chores:
- Remove Matthew from the CODEOWNERS configuration to reflect current maintainers.