### PR TITLE
remove meshing

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -10,13 +10,6 @@ parts:
         sections:
           - file: notebooks/ray_optimiser
           - file: notebooks/pso
-      - file: plugins_mesh
-        sections:
-          - file: notebooks/meshing_01_intro
-          - file: notebooks/meshing_02_2D_xy_mesh
-          - file: notebooks/meshing_03_2D_uz_mesh
-          - file: notebooks/meshing_04_refinement
-          - file: notebooks/meshing_05_3D
       - file: plugins_process
         sections:
           - file: notebooks/femwell_02_heater


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove the meshing plugin page and its associated meshing notebooks from the documentation navigation.