### PR TITLE
Activates PDK for notebook ``notebooks/workflow_3_cascaded_mzi.ipynb``

### DIFF
--- a/notebooks/workflow_3_cascaded_mzi.ipynb
+++ b/notebooks/workflow_3_cascaded_mzi.ipynb
@@ -31,7 +31,9 @@
     "import sax\n",
     "\n",
     "import gplugins.tidy3d as gt\n",
-    "from gplugins.common.config import PATH"
+    "from gplugins.common.config import PATH\n",
+    "\n",
+    "gf.gpdk.PDK.activate()"
    ]
   },
   {


### PR DESCRIPTION
Solves #673.

## Summary by Sourcery

New Features:
- Enable gf.gpdk PDK activation in the cascaded Mach–Zehnder interferometer workflow notebook.