### PR TITLE
Update tidy3d API calls for web and ``ModalComponentModeler``

### DIFF
--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -520,8 +520,6 @@ def write_sparameters(
         boundary_spec=boundary_spec,
         run_time=run_time,
         shutoff=shutoff,
-        # folder_name=folder_name,
-        # verbose=verbose,
         symmetry=symmetry,
         **kwargs,
     )


### PR DESCRIPTION
Solves issue with stale tidy3d notebook example code ``notebooks/workflow_3_cascaded_mzi.ipynb`` (issue #674) after adding in solution to activate PDK (issue #673 with related pull request #675):
```python
gf.gpdk.PDK.activate()
```

## Summary by Sourcery

Update tidy3d component modeling and S-parameter utilities to align with the latest web-based API and defaults.

Bug Fixes:
- Fix S-parameter computation by switching to web.run with explicit result handling instead of directly running the modeler.

Enhancements:
- Relax the default ModeSpec to remove TE polarization filtering for component modeling and S-parameter utilities.
- Remove obsolete folder/path/verbose arguments from component modeler construction and rely on updated modeler copying behavior.