### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,6 +1,10 @@
 name: Copilot Setup Steps
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: "v*"
 
+permissions:
+  contents: read
+
 jobs:
   release_pypi:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit `permissions: contents: read` to multiple GitHub Actions workflows to restrict the default scope of the `GITHUB_TOKEN` and address security alerts (https://github.com/gdsfactory/gplugins/security/code-scanning/8, https://github.com/gdsfactory/gplugins/security/code-scanning/7, https://github.com/gdsfactory/gplugins/security/code-scanning/6, https://github.com/gdsfactory/gplugins/security/code-scanning/5, https://github.com/gdsfactory/gplugins/security/code-scanning/4, https://github.com/gdsfactory/gplugins/security/code-scanning/3, https://github.com/gdsfactory/gplugins/security/code-scanning/2 & https://github.com/gdsfactory/gplugins/security/code-scanning/1).

## Summary by Sourcery

CI:
- Add explicit contents: read permissions to Copilot setup, Pages deployment, release, and test workflows to limit GITHUB_TOKEN scope.