### PR TITLE
Bump tidy3d to version >= 2.10 + fix a few bugs in meow making coverage testing fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,13 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
--Then you can install GDSFactory with:
+-Then you can install gplugins and its dependency groups with:
 
 ```bash
 uv venv --python 3.12
-uv sync --extra docs --extra dev
+uv sync --extra docs --extra dev # --extra tidy3d --extra femwell ...
 ```
+
 
 ## Getting started
 

--- a/gplugins/meow/meow_eme.py
+++ b/gplugins/meow/meow_eme.py
@@ -55,11 +55,11 @@ def _compute_s_matrix(modes_per_cell, cells):
     expects a list of {"p1": ..., "p2": ...} dicts (Nets). This wrapper
     converts the format.
     """
-    from meow.eme.sax import (
-        _get_netlist,
+    from meow.eme import (
         compute_interface_s_matrices,
         compute_propagation_s_matrices,
     )
+    from meow.eme.cascade import _get_netlist
 
     propagations = compute_propagation_s_matrices(modes_per_cell, cells)
     interfaces = compute_interface_s_matrices(modes_per_cell)
@@ -71,7 +71,7 @@ def _compute_s_matrix(modes_per_cell, cells):
     net["instances"] = {k: sax.scoo(v) for k, v in net["instances"].items()}
 
     # Convert old-style connections dict to new-style nets list
-    connections = net["connections"]
+    connections = net["nets"]
     if isinstance(connections, dict):
         nets = [{"p1": k, "p2": v} for k, v in connections.items()]
     else:

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -10,7 +10,7 @@ Functions:
     structures: Returns a list of Structure instances for each PolySlab in the component.
     get_ports: Returns a list of Port instances for each optical port in the component.
     get_simulation: Returns a Simulation instance for the component.
-    get_component_modeler: Returns a ComponentModeler instance for the component.
+    get_component_modeler: Returns a ModalComponentModeler instance for the component.
     plot_slice: Plots a cross section of the component at a specified position.
 """
 
@@ -30,7 +30,7 @@ from gdsfactory.technology import LayerStack
 from pydantic import NonNegativeFloat
 from tidy3d.components.geometry.base import from_shapely
 from tidy3d.components.types import Symmetry
-from tidy3d.plugins.smatrix import ComponentModeler, Port
+from tidy3d.plugins.smatrix import ModalComponentModeler, Port
 
 from gplugins.common.base_models.component import LayeredComponentBase
 from gplugins.tidy3d.get_results import _executor
@@ -233,38 +233,35 @@ class Tidy3DComponent(LayeredComponentBase):
         run_time: float = 10e-12,
         shutoff: float = 1e-5,
         grid_eps: float = 1e-6,
-        folder_name: str = "default",
-        path_dir: str = ".",
-        verbose: bool = True,
         symmetry: tuple[Symmetry, Symmetry, Symmetry] = (0, 0, 0),
         **kwargs,
-    ) -> ComponentModeler:
-        """Returns a ComponentModeler instance for the component.
+    ) -> ModalComponentModeler:
+        """Returns a ModalComponentModeler instance for the component.
 
         Args:
-            wavelength: The wavelength for the ComponentModeler. Defaults to 1.55.
-            bandwidth: The bandwidth for the ComponentModeler. Defaults to 0.2.
-            num_freqs: The number of frequencies for the ComponentModeler. Defaults to 21.
-            min_steps_per_wvl: The minimum number of steps per wavelength for the ComponentModeler. Defaults to 30.
-            center_z: The z-coordinate for the center of the ComponentModeler. If None, the z-coordinate of the component is used. Defaults to None.
-            sim_size_z: simulation size um in the z-direction for the ComponentModeler. Defaults to 4.
-            port_size_mult: The size multiplier for the ports in the ComponentModeler. Defaults to (4.0, 3.0).
-            run_only: The run only specification for the ComponentModeler. Defaults to None.
-            element_mappings: The element mappings for the ComponentModeler. Defaults to ().
-            extra_monitors: The extra monitors for the ComponentModeler. Defaults to None.
-            mode_spec: The mode specification for the ComponentModeler. Defaults to td.ModeSpec(num_modes=1).
-            boundary_spec: The boundary specification for the ComponentModeler. Defaults to td.BoundarySpec.all_sides(boundary=td.PML()).
-            run_time: The run time for the ComponentModeler.
-            shutoff: The shutoff value for the ComponentModeler. Defaults to 1e-5.
+            wavelength: The wavelength for the ModalComponentModeler. Defaults to 1.55.
+            bandwidth: The bandwidth for the ModalComponentModeler. Defaults to 0.2.
+            num_freqs: The number of frequencies for the ModalComponentModeler. Defaults to 21.
+            min_steps_per_wvl: The minimum number of steps per wavelength for the ModalComponentModeler. Defaults to 30.
+            center_z: The z-coordinate for the center of the ModalComponentModeler. If None, the z-coordinate of the component is used. Defaults to None.
+            sim_size_z: simulation size um in the z-direction for the ModalComponentModeler. Defaults to 4.
+            port_size_mult: The size multiplier for the ports in the ModalComponentModeler. Defaults to (4.0, 3.0).
+            run_only: The run only specification for the ModalComponentModeler. Defaults to None.
+            element_mappings: The element mappings for the ModalComponentModeler. Defaults to ().
+            extra_monitors: The extra monitors for the ModalComponentModeler. Defaults to None.
+            mode_spec: The mode specification for the ModalComponentModeler. Defaults to td.ModeSpec(num_modes=1).
+            boundary_spec: The boundary specification for the ModalComponentModeler. Defaults to td.BoundarySpec.all_sides(boundary=td.PML()).
+            run_time: The run time for the ModalComponentModeler.
+            shutoff: The shutoff value for the ModalComponentModeler. Defaults to 1e-5.
             grid_eps: Rounding tolerance for coordinates, e.g. port locations and layer centers (μm).
-            folder_name: The folder name for the ComponentModeler. Defaults to "default".
-            path_dir: The directory path for the ComponentModeler. Defaults to ".".
-            verbose: Whether to print verbose output for the ComponentModeler. Defaults to True.
+            folder_name: The folder name for the ModalComponentModeler. Defaults to "default".
+            path_dir: The directory path for the ModalComponentModeler. Defaults to ".".
+            verbose: Whether to print verbose output for the ModalComponentModeler. Defaults to True.
             symmetry (tuple[Symmetry, Symmetry, Symmetry], optional): The symmetry for the simulation. Defaults to (0,0,0).
             kwargs: Additional keyword arguments for the Simulation constructor.
 
         Returns:
-            ComponentModeler: A ComponentModeler instance.
+            ModalComponentModeler: A ModalComponentModeler instance.
         """
         match center_z:
             case float():
@@ -303,7 +300,7 @@ class Tidy3DComponent(LayeredComponentBase):
 
         ports = self.get_ports(mode_spec, port_size_mult, grid_eps=grid_eps)
 
-        return ComponentModeler(
+        return ModalComponentModeler(
             simulation=sim,
             ports=ports,
             freqs=tuple(freqs),
@@ -458,26 +455,26 @@ def write_sparameters(
         pad_z_inner: The inner padding in the z-direction. Defaults to 0.0.
         pad_z_outer: The outer padding in the z-direction. Defaults to 0.0.
         dilation: Dilation of the polygon in the base by shifting each edge along its normal outwards direction by a distance;
-        wavelength: The wavelength for the ComponentModeler. Defaults to 1.55.
-        bandwidth: The bandwidth for the ComponentModeler. Defaults to 0.2.
-        num_freqs: The number of frequencies for the ComponentModeler. Defaults to 21.
-        min_steps_per_wvl: The minimum number of steps per wavelength for the ComponentModeler. Defaults to 30.
-        center_z: The z-coordinate for the center of the ComponentModeler.
+        wavelength: The wavelength for the ModalComponentModeler. Defaults to 1.55.
+        bandwidth: The bandwidth for the ModalComponentModeler. Defaults to 0.2.
+        num_freqs: The number of frequencies for the ModalComponentModeler. Defaults to 21.
+        min_steps_per_wvl: The minimum number of steps per wavelength for the ModalComponentModeler. Defaults to 30.
+        center_z: The z-coordinate for the center of the ModalComponentModeler.
             If None, the z-coordinate of the component is used. Defaults to None.
-        sim_size_z: simulation size um in the z-direction for the ComponentModeler. Defaults to 4.
-        port_size_mult: The size multiplier for the ports in the ComponentModeler. Defaults to (4.0, 3.0).
-        run_only: The run only specification for the ComponentModeler. Defaults to None.
-        element_mappings: The element mappings for the ComponentModeler. Defaults to ().
-        extra_monitors: The extra monitors for the ComponentModeler. Defaults to None.
-        mode_spec: The mode specification for the ComponentModeler. Defaults to td.ModeSpec(num_modes=1).
-        boundary_spec: The boundary specification for the ComponentModeler.
+        sim_size_z: simulation size um in the z-direction for the ModalComponentModeler. Defaults to 4.
+        port_size_mult: The size multiplier for the ports in the ModalComponentModeler. Defaults to (4.0, 3.0).
+        run_only: The run only specification for the ModalComponentModeler. Defaults to None.
+        element_mappings: The element mappings for the ModalComponentModeler. Defaults to ().
+        extra_monitors: The extra monitors for the ModalComponentModeler. Defaults to None.
+        mode_spec: The mode specification for the ModalComponentModeler. Defaults to td.ModeSpec(num_modes=1).
+        boundary_spec: The boundary specification for the ModalComponentModeler.
             Defaults to td.BoundarySpec.all_sides(boundary=td.PML()).
         symmetry (tuple[Symmetry, Symmetry, Symmetry], optional): The symmetry for the simulation. Defaults to (0,0,0).
-        run_time: The run time for the ComponentModeler.
-        shutoff: The shutoff value for the ComponentModeler. Defaults to 1e-5.
-        folder_name: The folder name for the ComponentModeler in flexcompute website. Defaults to "default".
+        run_time: The run time for the ModalComponentModeler.
+        shutoff: The shutoff value for the ModalComponentModeler. Defaults to 1e-5.
+        folder_name: The folder name for the ModalComponentModeler in flexcompute website. Defaults to "default".
         dirpath: Optional directory path for writing the Sparameters. Defaults to "~/.gdsfactory/sparameters".
-        verbose: Whether to print verbose output for the ComponentModeler. Defaults to True.
+        verbose: Whether to print verbose output for the ModalComponentModeler. Defaults to True.
         plot_simulation_layer_name: Optional layer name to plot. Defaults to None.
         plot_simulation_port_index: which port index to plot. Defaults to 0.
         plot_simulation_z: which z coordinate to plot. Defaults to None.
@@ -588,7 +585,7 @@ def write_sparameters(
     else:
         time.sleep(0.2)
         modeler_data = web.run(
-            modeler,  # TODO: web.run does not currently support ComponentModeler, need to convert to tidy3d_stub.SimulationType
+            modeler,  # TODO: web.run does not currently support ModalComponentModeler, need to convert to tidy3d_stub.SimulationType
             task_name=task_name,
             verbose=verbose,
             path=path_dir / "simulation.hdf5",
@@ -636,26 +633,26 @@ def write_sparameters_batch(
         pad_z_inner: The inner padding in the z-direction. Defaults to 0.0.
         pad_z_outer: The outer padding in the z-direction. Defaults to 0.0.
         dilation: Dilation of the polygon in the base by shifting each edge along its normal outwards direction by a distance;
-        wavelength: The wavelength for the ComponentModeler. Defaults to 1.55.
-        bandwidth: The bandwidth for the ComponentModeler. Defaults to 0.2.
-        num_freqs: The number of frequencies for the ComponentModeler. Defaults to 21.
-        min_steps_per_wvl: The minimum number of steps per wavelength for the ComponentModeler. Defaults to 30.
-        center_z: The z-coordinate for the center of the ComponentModeler.
+        wavelength: The wavelength for the ModalComponentModeler. Defaults to 1.55.
+        bandwidth: The bandwidth for the ModalComponentModeler. Defaults to 0.2.
+        num_freqs: The number of frequencies for the ModalComponentModeler. Defaults to 21.
+        min_steps_per_wvl: The minimum number of steps per wavelength for the ModalComponentModeler. Defaults to 30.
+        center_z: The z-coordinate for the center of the ModalComponentModeler.
             If None, the z-coordinate of the component is used. Defaults to None.
-        sim_size_z: simulation size um in the z-direction for the ComponentModeler. Defaults to 4.
-        port_size_mult: The size multiplier for the ports in the ComponentModeler. Defaults to (4.0, 3.0).
-        run_only: The run only specification for the ComponentModeler. Defaults to None.
-        element_mappings: The element mappings for the ComponentModeler. Defaults to ().
-        extra_monitors: The extra monitors for the ComponentModeler. Defaults to None.
-        mode_spec: The mode specification for the ComponentModeler. Defaults to td.ModeSpec(num_modes=1).
-        boundary_spec: The boundary specification for the ComponentModeler.
+        sim_size_z: simulation size um in the z-direction for the ModalComponentModeler. Defaults to 4.
+        port_size_mult: The size multiplier for the ports in the ModalComponentModeler. Defaults to (4.0, 3.0).
+        run_only: The run only specification for the ModalComponentModeler. Defaults to None.
+        element_mappings: The element mappings for the ModalComponentModeler. Defaults to ().
+        extra_monitors: The extra monitors for the ModalComponentModeler. Defaults to None.
+        mode_spec: The mode specification for the ModalComponentModeler. Defaults to td.ModeSpec(num_modes=1).
+        boundary_spec: The boundary specification for the ModalComponentModeler.
             Defaults to td.BoundarySpec.all_sides(boundary=td.PML()).
         symmetry (tuple[Symmetry, Symmetry, Symmetry], optional): The symmetry for the simulation. Defaults to (0,0,0).
-        run_time: The run time for the ComponentModeler. Defaults to 1e-12.
-        shutoff: The shutoff value for the ComponentModeler. Defaults to 1e-5.
-        folder_name: The folder name for the ComponentModeler in flexcompute website. Defaults to "default".
+        run_time: The run time for the ModalComponentModeler. Defaults to 1e-12.
+        shutoff: The shutoff value for the ModalComponentModeler. Defaults to 1e-5.
+        folder_name: The folder name for the ModalComponentModeler in flexcompute website. Defaults to "default".
         dirpath: Optional directory path for writing the Sparameters. Defaults to "~/.gdsfactory/sparameters".
-        verbose: Whether to print verbose output for the ComponentModeler. Defaults to True.
+        verbose: Whether to print verbose output for the ModalComponentModeler. Defaults to True.
         plot_simulation_layer_name: Optional layer name to plot. Defaults to None.
         plot_simulation_port_index: which port index to plot. Defaults to 0.
         plot_simulation_z: which z coordinate to plot. Defaults to None.

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -254,9 +254,6 @@ class Tidy3DComponent(LayeredComponentBase):
             run_time: The run time for the ModalComponentModeler.
             shutoff: The shutoff value for the ModalComponentModeler. Defaults to 1e-5.
             grid_eps: Rounding tolerance for coordinates, e.g. port locations and layer centers (μm).
-            folder_name: The folder name for the ModalComponentModeler. Defaults to "default".
-            path_dir: The directory path for the ModalComponentModeler. Defaults to ".".
-            verbose: Whether to print verbose output for the ModalComponentModeler. Defaults to True.
             symmetry (tuple[Symmetry, Symmetry, Symmetry], optional): The symmetry for the simulation. Defaults to (0,0,0).
             kwargs: Additional keyword arguments for the Simulation constructor.
 

--- a/gplugins/tidy3d/materials.py
+++ b/gplugins/tidy3d/materials.py
@@ -5,7 +5,7 @@ from typing import TypeAlias
 
 import tidy3d as td
 from tidy3d.components.medium import PoleResidue
-from tidy3d.components.types import ComplexNumber
+from tidy3d.components.types import Complex
 
 material_name_to_tidy3d = {
     "si": td.material_library["cSi"]["Li1993_293K"],
@@ -28,7 +28,7 @@ MaterialSpecTidy3d: TypeAlias = (
 def get_epsilon(
     spec: MaterialSpecTidy3d,
     wavelength: float = 1.55,
-) -> ComplexNumber:
+) -> Complex:
     """Return permittivity from material database.
 
     Args:

--- a/gplugins/tidy3d/modes.py
+++ b/gplugins/tidy3d/modes.py
@@ -35,7 +35,7 @@ Precision = Literal["single", "double"]
 nm = 1e-3
 
 
-def custom_serializer(data: str | float | BaseModel) -> str:
+def custom_serializer(data: str | float | BaseModel | td.Medium) -> str:
     # If data is a string, just return it.
     if isinstance(data, str | None | np.ndarray):
         return data
@@ -45,7 +45,7 @@ def custom_serializer(data: str | float | BaseModel) -> str:
         return str(data)
 
     # If data is an instance of Pydantic's BaseModel, serialize it to JSON.
-    if isinstance(data, BaseModel):
+    if isinstance(data, BaseModel | td.CustomMedium | td.Medium | td.PoleResidue):
         return data.json()
 
     # If data is a list or tuple, recursively serialize each element.

--- a/gplugins/tidy3d/modes.py
+++ b/gplugins/tidy3d/modes.py
@@ -60,7 +60,7 @@ def custom_serializer(data: str | float | BaseModel) -> str:
     raise ValueError(f"Unsupported data type: {type(data)}")
 
 
-class Waveguide(BaseModel, extra="forbid"):
+class Waveguide(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     """Waveguide Model.
 
     All dimensions must be specified in μm (1e-6 m).

--- a/gplugins/tidy3d/tests/test_component_modeler.py
+++ b/gplugins/tidy3d/tests/test_component_modeler.py
@@ -1,5 +1,5 @@
 import gdsfactory as gf
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 
 import gplugins.tidy3d as gt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pytest-cov",
   "pytest_regressions"
 ]
-devsim = ["devsim", "pyvista<=0.46.0", "tidy3d>=2.8.2,<2.9"]
+devsim = ["devsim", "pyvista<=0.46.0", "tidy3d>=2.10"]
 docs = [
   "jupytext",
   "matplotlib",
@@ -51,12 +51,12 @@ gfviz = ["jinja2", "fastapi", "shapely", "natsort"]
 klayout = ["klayout", "pyvis<=0.3.1", "vlsir", "vlsirtools", "gitpython"]
 luminescent = ["luminescent>=0.2.12,<0.4.0", "sortedcontainers"]
 maintainer = ["mypy", "tbump", "towncrier"]
-meow = ["meow-sim>=0.14.1,<0.15", "sax~=0.16.3", "tidy3d>=2.8.2,<2.9"]
+meow = ["meow-sim>=0.15", "sax~=0.16.3", "tidy3d>=2.10"]
 meshwell = ["shapely", "meshwell~=2.1.1"]
 path_length_analysis = ["bokeh", "numba", "shapely"]
 sax = ["sax~=0.16.3"]
 schematic = ["bokeh", "ipywidgets", "natsort"]
-tidy3d = ["tidy3d>=2.8.2,<2.9", "gdstk", "pytz"]
+tidy3d = ["tidy3d>=2.10", "gdstk", "pytz"]
 vlsir = ["vlsir", "vlsirtools"]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pytest-cov",
   "pytest_regressions"
 ]
-devsim = ["devsim", "pyvista<=0.46.0", "tidy3d>=2.10"]
+devsim = ["devsim", "pyvista<=0.46.0", "tidy3d~=2.11.1"]
 docs = [
   "jupytext",
   "matplotlib",
@@ -51,12 +51,12 @@ gfviz = ["jinja2", "fastapi", "shapely", "natsort"]
 klayout = ["klayout", "pyvis<=0.3.1", "vlsir", "vlsirtools", "gitpython"]
 luminescent = ["luminescent>=0.2.12,<0.4.0", "sortedcontainers"]
 maintainer = ["mypy", "tbump", "towncrier"]
-meow = ["meow-sim>=0.15", "sax~=0.16.3", "tidy3d>=2.10"]
+meow = ["meow-sim>=0.15", "sax~=0.16.3", "tidy3d~=2.11.1"]
 meshwell = ["shapely", "meshwell~=2.1.1"]
 path_length_analysis = ["bokeh", "numba", "shapely"]
 sax = ["sax~=0.16.3"]
 schematic = ["bokeh", "ipywidgets", "natsort"]
-tidy3d = ["tidy3d>=2.10", "gdstk", "pytz"]
+tidy3d = ["tidy3d~=2.11.1", "gdstk", "pytz"]  # pin max version because tidy3d often introduces breaking API changes across minor releases
 vlsir = ["vlsir", "vlsirtools"]
 
 [tool.codespell]


### PR DESCRIPTION
## Breaking changes
- Bumped `tidy3d` to >=2.10

## Fixes
- In `gplugins/meow/meow_eme.py`, `_compute_s_matrix(modes_per_cell, cells)` was:
   -  Using calling `net["connections"]` when the correct field name is `net["nets"]`.
   -  Not importing functions from meow.eme correctly.
- In `gplugins/tidy3d/modes.py`, `custom_serializer()` couldn't handle tidy3d Medium objects, causing an error when instanciating a `Waveguide` object with td Mediums as arguments.
- In `gplugins/tidy3d/materials.py`, `ComplexNumber` is deprecated and replaced by `Complex`.

## Refactors
- `tidy3d.plugins.smatrix.ComponentModeler` is deprecated -> `tidy3d.plugins.smatrix.ModalComponentModeler`.
- `gdsfactory.generic_tech` is deprecated -> `gdsfactory.gpdk`

## Docs
- Added instructions on loading specific optional dependency groups with `uv sync`

## Related issues
Closes #697

## Summary by Sourcery

Update tidy3d- and meow-related integrations to support tidy3d>=2.10 and newer meow APIs while aligning type usage and documentation.

Bug Fixes:
- Fix meow EME S-matrix construction by importing cascade utilities from the correct modules and using the updated netlist field name.
- Allow tidy3d-based Waveguide models to serialize tidy3d Medium and related custom medium types without errors.

Enhancements:
- Replace deprecated tidy3d ComponentModeler usage with ModalComponentModeler across component modeling helpers and docstrings.
- Update tidy3d material handling to use the new Complex type instead of the deprecated ComplexNumber.
- Relax Pydantic typing in the Waveguide model to permit arbitrary tidy3d types for improved compatibility.

Build:
- Bump tidy3d dependency to version >=2.10 across relevant optional dependency groups and align meow optional dependency versions.

Documentation:
- Clarify README instructions for installing gplugins with uv, including how to select specific optional dependency groups.