### PR TITLE
Temporary fix of the palace CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt-get install -y libglu1-mesa
       - name: Download Palace singularity definition
-        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def
+        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def # Newer versions of palace have deprecated singularity definitions, so we pin to a specific version. TODO: Update this
       - name: Cache Palace container restore
         id: cache-palace-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt-get install -y libglu1-mesa
       - name: Download Palace singularity definition
-        run: wget https://raw.githubusercontent.com/awslabs/palace/main/singularity/singularity.def
+        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def
       - name: Cache Palace container restore
         id: cache-palace-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           sudo apt-get install -y libglu1-mesa
       - name: Download Palace singularity definition
-        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def
+        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def # Newer versions of palace have deprecated singularity definitions, so we pin to a specific version. TODO: Update this
       - name: Cache Palace container restore
         id: cache-palace-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           sudo apt-get install -y libglu1-mesa
       - name: Download Palace singularity definition
-        run: wget https://raw.githubusercontent.com/awslabs/palace/main/singularity/singularity.def
+        run: wget https://raw.githubusercontent.com/awslabs/palace/refs/tags/v0.16.0/singularity/singularity.def
       - name: Cache Palace container restore
         id: cache-palace-restore
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Summary
As of Palace `v0.16.1`, building palace from `singularity.def` is no longer supported.

This PR is a temporary fix that pins the version of the repository to `v0.16.0` in the GitHub action workflow to prevent the HTTP error.

A more permanant fix would involve using the newer build procedure.

## Related issue
Addresses #699

## Summary by Sourcery

CI:
- Update pages and test_code GitHub workflows to download the Palace Singularity definition from the v0.16.0 tag instead of main.