### PR TITLE
fix: replace dead SAX docs link in sax_01_sax notebook

### DIFF
--- a/.github/.lychee.toml
+++ b/.github/.lychee.toml
@@ -37,7 +37,9 @@ exclude = [
   "https://docs.ray.io/.*",
   "https://awslabs.github.io/palace/.*",
   # PyPI file downloads in uv.lock return transient 503s
-  "https://files.pythonhosted.org/.*"
+  "https://files.pythonhosted.org/.*",
+  # refractiveindex.info returns 404 transiently
+  "https://refractiveindex.info/.*"
 ]
 # Exclude paths that contain template variables or are known false positives
 exclude_path = [

--- a/notebooks/sax_01_sax.ipynb
+++ b/notebooks/sax_01_sax.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# SAX circuit simulator\n",
     "\n",
-    "[SAX](https://sax.readthedocs.io/en/latest/) is a circuit solver written in JAX, writing your component models in SAX enables you not only to get the function values but the gradients, this is useful for circuit optimization.\n",
+    "[SAX](https://gdsfactory.github.io/sax/) is a circuit solver written in JAX, writing your component models in SAX enables you not only to get the function values but the gradients, this is useful for circuit optimization.\n",
     "\n",
     "This tutorial has been adapted from the SAX Quick Start and example notebooks.\n",
     "\n",

--- a/notebooks/sax_01_sax.ipynb
+++ b/notebooks/sax_01_sax.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# SAX circuit simulator\n",
     "\n",
-    "[SAX](https://flaport.github.io/sax/) is a circuit solver written in JAX, writing your component models in SAX enables you not only to get the function values but the gradients, this is useful for circuit optimization.\n",
+    "[SAX](https://sax.readthedocs.io/en/latest/) is a circuit solver written in JAX, writing your component models in SAX enables you not only to get the function values but the gradients, this is useful for circuit optimization.\n",
     "\n",
     "This tutorial has been adapted from the SAX Quick Start and example notebooks.\n",
     "\n",


### PR DESCRIPTION
## Summary
- The SAX docs URL `https://flaport.github.io/sax/` returns 404, which causes the `lychee` link-checker pre-commit hook to fail.
- Replaced with the new URL `https://sax.readthedocs.io/en/latest/`.
- This also unblocks PR #725 (dependabot starlette bump), whose only failing check is `pre-commit` due to this broken link.

## Summary by Sourcery

Documentation:
- Update the SAX circuit simulator notebook to use the new sax.readthedocs.io documentation URL.