### PR TITLE
fix: follow symlinks in nbdocs so notebook pages render

### DIFF
--- a/.github/.lychee.toml
+++ b/.github/.lychee.toml
@@ -24,6 +24,8 @@ exclude = [
   "https://www.lumerical.com/.*",
   "https://support.lumerical.com/.*",
   "https://optics.ansys.com/.*",
+  # IEEE blocks automated crawlers with 418
+  "https://ieeexplore.ieee.org/.*",
   # Consistently returns non-200 despite valid content
   "https://mathworld.wolfram.com/.*",
   "https://nbviewer.org/.*",

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ NOEXEC_PATTERNS = 01_pin_waveguide|1_fdtd_sparameters|2_interconnect|ray_optimis
 
 nbdocs:
 	@echo "Converting notebooks to markdown..."
-	@find docs -name "*.ipynb" | while read nb; do \
+	@find -L docs -name "*.ipynb" | while read nb; do \
 		if echo "$$nb" | grep -qE '$(NOEXEC_PATTERNS)'; then \
 			echo "  [no-exec] $$nb"; \
 			jupyter nbconvert --to markdown --embed-images "$$nb" 2>/dev/null || true; \


### PR DESCRIPTION
## Summary

- `docs/notebooks` is a symlink to `../notebooks`. The `find` command in the `nbdocs` Makefile target doesn't follow symlinks by default, so it finds zero `.ipynb` files and generates zero markdown — leaving every notebook nav entry broken (title "none", link 404).
- Fix: add `-L` flag to `find` so it follows the symlink.

Fixes #743

## Test plan

- [ ] CI docs build passes
- [ ] Notebook pages render with proper titles in the nav sidebar
- [ ] Workflow pages (workflow_1_mzi, workflow_2_ring, workflow_3_cascaded_mzi) load without 404

Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update nbdocs Makefile target to run find with symlink-following so .ipynb files under symlinked docs paths are discovered.