### PR TITLE
fix: resolve docs/notebooks symlink so notebook pages render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,13 @@ NOEXEC_PATTERNS = 01_pin_waveguide|1_fdtd_sparameters|2_interconnect|ray_optimis
 
 nbdocs:
 	@echo "Converting notebooks to markdown..."
-	@find -L docs -name "*.ipynb" | while read nb; do \
+	@# Resolve symlink so zensical can discover the generated .md files
+	@if [ -L docs/notebooks ]; then \
+		target=$$(readlink -f docs/notebooks) && \
+		rm docs/notebooks && \
+		cp -r "$$target" docs/notebooks; \
+	fi
+	@find docs -name "*.ipynb" | while read nb; do \
 		if echo "$$nb" | grep -qE '$(NOEXEC_PATTERNS)'; then \
 			echo "  [no-exec] $$nb"; \
 			jupyter nbconvert --to markdown --embed-images "$$nb" 2>/dev/null || true; \


### PR DESCRIPTION
## Summary

Follow-up to #744. The previous fix (`find -L`) solved notebook discovery but the pages still 404 because **zensical/mkdocs also doesn't follow symlinks** when scanning `docs_dir` for source files. The generated `.md` files exist (build logs show all 32 notebooks converted) but zensical never picks them up.

This PR replaces the symlink with a real directory copy at the start of the `nbdocs` target:
```
if [ -L docs/notebooks ]; then
    target=$(readlink -f docs/notebooks)
    rm docs/notebooks
    cp -r "$target" docs/notebooks
fi
```

This resolves both issues at once — `find` and zensical both see a real directory.

Fixes #743

## Test plan

- [ ] CI docs build passes
- [ ] Deployed site shows notebook pages with proper titles (not "none")
- [ ] Notebook pages load without 404

Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve docs/notebooks symlink before nbdocs conversion so mkdocs/zensical can detect generated notebook markdown files.