### PR TITLE
fix: use tqdm.auto for proper notebook progress bar rendering

### DIFF
--- a/notebooks/femwell_01_modes.ipynb
+++ b/notebooks/femwell_01_modes.ipynb
@@ -34,7 +34,7 @@
     "from shapely.ops import clip_by_rect\n",
     "from skfem import Basis, ElementTriP0\n",
     "from skfem.io.meshio import from_meshio\n",
-    "from tqdm import tqdm"
+    "from tqdm.auto import tqdm"
    ]
   },
   {

--- a/notebooks/femwell_02_heater.ipynb
+++ b/notebooks/femwell_02_heater.ipynb
@@ -88,7 +88,7 @@
     "from shapely.geometry import LineString, Polygon\n",
     "from skfem import Basis, ElementTriP0\n",
     "from skfem.io import from_meshio\n",
-    "from tqdm import tqdm"
+    "from tqdm.auto import tqdm"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Replace `from tqdm import tqdm` with `from tqdm.auto import tqdm` in `notebooks/femwell_01_modes.ipynb` and `notebooks/femwell_02_heater.ipynb`
- `tqdm.auto` automatically selects the appropriate progress bar backend: interactive widgets in Jupyter, standard console bars elsewhere
- Fixes raw text progress bar output in notebook environments

Closes #750

> Reminder: AI-created PRs still require human review of the actual code changes before merge.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect raw text progress bar output in Jupyter notebook runs by switching to tqdm.auto in FEMWELL mode and heater notebooks.