### PR TITLE
rename deprecated generic_tech to gpdk

### DIFF
--- a/gplugins/common/utils/tests/test_get_component_with_new_port_layers.py
+++ b/gplugins/common/utils/tests/test_get_component_with_new_port_layers.py
@@ -1,5 +1,5 @@
 from gdsfactory.components import straight_heater_metal
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 
 from gplugins.common.utils.get_component_with_net_layers import (
     get_component_layer_stack,

--- a/gplugins/devsim/doping.py
+++ b/gplugins/devsim/doping.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 
 import numpy as np
-from gdsfactory.generic_tech import LAYER
+from gdsfactory.gpdk import LAYER
 from gdsfactory.typings import Layer
 from pydantic import BaseModel, ConfigDict
 

--- a/gplugins/devsim/get_simulation.py
+++ b/gplugins/devsim/get_simulation.py
@@ -230,7 +230,7 @@ def create_2Duz_simulation(
 
 if __name__ == "__main__":
     import gdsfactory as gf
-    from gdsfactory.generic_tech import LAYER, LAYER_STACK
+    from gdsfactory.gpdk import LAYER, LAYER_STACK
 
     # We choose a representative subdomain of the component
     waveguide = gf.Component()

--- a/gplugins/elmer/get_capacitance.py
+++ b/gplugins/elmer/get_capacitance.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import gdsfactory as gf
 import gmsh
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 from gdsfactory.technology import LayerStack
 from jinja2 import Environment, FileSystemLoader
 from numpy import isfinite

--- a/gplugins/elmer/tests/test_elmer.py
+++ b/gplugins/elmer/tests/test_elmer.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 import pytest
 from gdsfactory.component import Component
 from gdsfactory.components import interdigital_capacitor_enclosed
-from gdsfactory.generic_tech import LAYER
+from gdsfactory.gpdk import LAYER
 from gdsfactory.technology import LayerStack
 from gdsfactory.technology.layer_stack import LayerLevel
 

--- a/gplugins/fdtdz/get_epsilon_fdtdz.py
+++ b/gplugins/fdtdz/get_epsilon_fdtdz.py
@@ -215,7 +215,7 @@ def add_plot_labels(arg0, arg1, arg2, arg3) -> None:
 
 if __name__ == "__main__":
     import gdsfactory as gf
-    from gdsfactory.generic_tech import LAYER, LAYER_STACK
+    from gdsfactory.gpdk import LAYER, LAYER_STACK
 
     length = 5
 

--- a/gplugins/fdtdz/get_ports_fdtdz.py
+++ b/gplugins/fdtdz/get_ports_fdtdz.py
@@ -190,7 +190,7 @@ def plot_mode(
 
 if __name__ == "__main__":
     import gdsfactory as gf
-    from gdsfactory.generic_tech import LAYER, LAYER_STACK
+    from gdsfactory.gpdk import LAYER, LAYER_STACK
 
     from gplugins.fdtdz.get_epsilon_fdtdz import component_to_epsilon_pjz
 

--- a/gplugins/fdtdz/get_sparameters_fdtdz.py
+++ b/gplugins/fdtdz/get_sparameters_fdtdz.py
@@ -147,7 +147,7 @@ def get_sparameters_fdtdz(
 
 
 if __name__ == "__main__":
-    from gdsfactory.generic_tech import LAYER, LAYER_STACK
+    from gdsfactory.gpdk import LAYER, LAYER_STACK
 
     length = 5
 

--- a/gplugins/femwell/test_mode_solver.py
+++ b/gplugins/femwell/test_mode_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 from gdsfactory.technology import LayerStack
 from meshwell.resolution import ConstantInField
 

--- a/gplugins/klayout/dataprep/regions.py
+++ b/gplugins/klayout/dataprep/regions.py
@@ -200,7 +200,7 @@ class RegionCollection:
 
 if __name__ == "__main__":
     import kfactory as kf
-    from gdsfactory.generic_tech import LAYER
+    from gdsfactory.gpdk import LAYER
 
     c = gf.Component()
     ring = c << gf.components.coupler_ring()

--- a/gplugins/klayout/drc/check_width.py
+++ b/gplugins/klayout/drc/check_width.py
@@ -58,7 +58,7 @@ def demo() -> None:
 
 if __name__ == "__main__":
     import gdsfactory as gf
-    from gdsfactory.generic_tech import LAYER
+    from gdsfactory.gpdk import LAYER
 
     w = 0.12
     c = gf.components.rectangle(size=(w, w), layer=LAYER.WG)

--- a/gplugins/klayout/drc/write_drc.py
+++ b/gplugins/klayout/drc/write_drc.py
@@ -402,7 +402,7 @@ def write_drc_deck_macro(
             check_area,
             check_density,
         )
-        from gdsfactory.generic_tech import LAYER
+        from gdsfactory.gpdk import LAYER
         rules = [
             check_width(layer="WG", value=0.2),
             check_space(layer="WG", value=0.2),
@@ -445,7 +445,7 @@ def write_drc_deck_macro(
 
 
 if __name__ == "__main__":
-    from gdsfactory.generic_tech import LAYER
+    from gdsfactory.gpdk import LAYER
 
     rules = [
         derived_layer_boolean("TRENCH", "SLAB90", "-", "WG"),

--- a/gplugins/klayout/tests/test_dataprep_regions.py
+++ b/gplugins/klayout/tests/test_dataprep_regions.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import gdsfactory as gf
 import pytest
-from gdsfactory.generic_tech.layer_map import LAYER
+from gdsfactory.gpdk.layer_map import LAYER
 from kfactory import kdb
 
 import gplugins.klayout.dataprep.regions as dp

--- a/gplugins/lumerical/read.py
+++ b/gplugins/lumerical/read.py
@@ -7,7 +7,7 @@ import gdsfactory as gf
 import numpy as np
 from gdsfactory import logger
 from gdsfactory.component import Component
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 from gdsfactory.technology import LayerStack
 
 from gplugins.common.utils.get_sparameters_path import (

--- a/gplugins/lumerical/write_sparameters_lumerical.py
+++ b/gplugins/lumerical/write_sparameters_lumerical.py
@@ -11,7 +11,7 @@ import numpy as np
 import yaml
 from gdsfactory import logger
 from gdsfactory.config import __version__
-from gdsfactory.generic_tech.simulation_settings import (
+from gdsfactory.gpdk.simulation_settings import (
     SIMULATION_SETTINGS_LUMERICAL_FDTD,
     SimulationSettingsLumericalFdtd,
 )

--- a/gplugins/meshwell/get_meshwell_3D.py
+++ b/gplugins/meshwell/get_meshwell_3D.py
@@ -6,7 +6,7 @@ import math
 import kfactory as kf
 from gdsfactory.add_padding import add_padding_container, add_padding
 from functools import partial
-from gdsfactory.generic_tech.layer_map import LAYER
+from gdsfactory.gpdk.layer_map import LAYER
 from gplugins.common.utils.geometry import region_to_shapely_polygons
 
 
@@ -106,8 +106,8 @@ def get_meshwell_prisms(
 
 if __name__ == "__main__":
     from gdsfactory.components import ge_detector_straight_si_contacts, add_frame
-    from gdsfactory.generic_tech.layer_stack import get_layer_stack
-    from gdsfactory.generic_tech.layer_map import LAYER
+    from gdsfactory.gpdk.layer_stack import get_layer_stack
+    from gdsfactory.gpdk.layer_map import LAYER
     from meshwell.cad import cad
     from meshwell.mesh import mesh
 

--- a/gplugins/meshwell/get_meshwell_cross_section.py
+++ b/gplugins/meshwell/get_meshwell_cross_section.py
@@ -8,7 +8,7 @@ import math
 import kfactory as kf
 from gdsfactory.add_padding import add_padding_container, add_padding
 from functools import partial
-from gdsfactory.generic_tech.layer_map import LAYER
+from gdsfactory.gpdk.layer_map import LAYER
 from typing import Literal
 import numpy as np
 from gplugins.common.utils.geometry import region_to_shapely_polygons
@@ -205,8 +205,8 @@ def _linestring_to_cross_section_polygon(linestring, layer_level: gf.technology.
 if __name__ == "__main__":
 
     from gdsfactory.components import ge_detector_straight_si_contacts
-    from gdsfactory.generic_tech.layer_stack import get_layer_stack
-    from gdsfactory.generic_tech.layer_map import LAYER
+    from gdsfactory.gpdk.layer_stack import get_layer_stack
+    from gdsfactory.gpdk.layer_map import LAYER
     from meshwell.cad import cad
     from meshwell.mesh import mesh
 

--- a/gplugins/meshwell/tests/test_meshwell.py
+++ b/gplugins/meshwell/tests/test_meshwell.py
@@ -3,7 +3,7 @@ import gdsfactory as gf
 
 
 from gdsfactory.components import bend_circular, add_frame
-from gdsfactory.generic_tech.layer_stack import get_layer_stack
+from gdsfactory.gpdk.layer_stack import get_layer_stack
 from meshwell.cad import cad
 from meshwell.mesh import mesh
 from pathlib import Path

--- a/gplugins/palace/get_capacitance.py
+++ b/gplugins/palace/get_capacitance.py
@@ -15,7 +15,7 @@ from gdsfactory.typings import Ports
 from kfactory import kdb
 import gdsfactory as gf
 import gmsh
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 from gdsfactory.technology import LayerStack
 from numpy import isfinite
 from pandas import read_csv

--- a/gplugins/palace/get_scattering.py
+++ b/gplugins/palace/get_scattering.py
@@ -15,7 +15,7 @@ from typing import Any
 import gdsfactory as gf
 import gmsh
 import pandas as pd
-from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.gpdk import LAYER_STACK
 from gdsfactory.technology import LayerStack
 from numpy import isfinite
 

--- a/gplugins/palace/tests/test_palace.py
+++ b/gplugins/palace/tests/test_palace.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.components.analog.interdigital_capacitor import (
     interdigital_capacitor,
 )
-from gdsfactory.generic_tech import LAYER
+from gdsfactory.gpdk import LAYER
 from gdsfactory.technology import LayerStack
 from gdsfactory.technology.layer_stack import LayerLevel
 

--- a/gplugins/sentaurus/sde.py
+++ b/gplugins/sentaurus/sde.py
@@ -258,8 +258,8 @@ def write_sde(
 
 if __name__ == "__main__":
     from gdsfactory.components import straight_pn
-    from gdsfactory.generic_tech import LAYER
-    from gdsfactory.generic_tech.layer_stack import WAFER_STACK
+    from gdsfactory.gpdk import LAYER
+    from gdsfactory.gpdk.layer_stack import WAFER_STACK
 
     # Create a component with the right contacts
     length = 3
@@ -298,7 +298,7 @@ if __name__ == "__main__":
     #                )
 
     # Tweak process
-    from gdsfactory.generic_tech.layer_stack import LayerStackParameters
+    from gdsfactory.gpdk.layer_stack import LayerStackParameters
     from gdsfactory.technology.processes import ProcessStep
 
     def get_process() -> tuple[ProcessStep]:

--- a/gplugins/sentaurus/sprocess.py
+++ b/gplugins/sentaurus/sprocess.py
@@ -569,8 +569,8 @@ struct tdr= pn_test_msh_zcut_remeshed
 
 if __name__ == "__main__":
     from gdsfactory.components import straight_pn
-    from gdsfactory.generic_tech import LAYER
-    from gdsfactory.generic_tech.layer_stack import WAFER_STACK, get_process
+    from gdsfactory.gpdk import LAYER
+    from gdsfactory.gpdk.layer_stack import WAFER_STACK, get_process
 
     # Create a component with the right contacts
     c = gf.Component(name="test_pn")

--- a/notebooks/elmer_01_electrostatic.ipynb
+++ b/notebooks/elmer_01_electrostatic.ipynb
@@ -43,7 +43,7 @@
     "from gdsfactory.components.interdigital_capacitor_enclosed import (\n",
     "    interdigital_capacitor_enclosed,\n",
     ")\n",
-    "from gdsfactory.generic_tech import LAYER, get_generic_pdk\n",
+    "from gdsfactory.gpdk import LAYER, get_generic_pdk\n",
     "from gdsfactory.technology import LayerStack\n",
     "from gdsfactory.technology.layer_stack import LayerLevel\n",
     "\n",

--- a/notebooks/fdtdz_01.ipynb
+++ b/notebooks/fdtdz_01.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "import gdsfactory as gf\n",
     "from gdsfactory.cross_section import rib\n",
-    "from gdsfactory.generic_tech import LAYER, LAYER_STACK\n",
+    "from gdsfactory.gpdk import LAYER, LAYER_STACK\n",
     "from gdsfactory.technology import LayerStack\n",
     "\n",
     "from gplugins.fdtdz.get_sparameters_fdtdz import get_sparameters_fdtdz\n",

--- a/notebooks/femwell_02_heater.ipynb
+++ b/notebooks/femwell_02_heater.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "import gdsfactory as gf\n",
     "import meshio\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "from gdsfactory.technology import LayerStack\n",
     "from skfem.io import from_meshio\n",
     "\n",

--- a/notebooks/klayout_dataprep.ipynb
+++ b/notebooks/klayout_dataprep.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "from gdsfactory.generic_tech.layer_map import LAYER\n",
+    "from gdsfactory.gpdk.layer_map import LAYER\n",
     "\n",
     "import gplugins.klayout.dataprep as dp"
    ]

--- a/notebooks/klayout_drc.ipynb
+++ b/notebooks/klayout_drc.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import gdsfactory as gf\n",
     "from gdsfactory.component import Component\n",
-    "from gdsfactory.generic_tech import LAYER\n",
+    "from gdsfactory.gpdk import LAYER\n",
     "from gdsfactory.typings import Float2, Layer\n",
     "\n",
     "from gplugins.klayout.drc.write_drc import (\n",

--- a/notebooks/lumerical_1_fdtd_sparameters.ipynb
+++ b/notebooks/lumerical_1_fdtd_sparameters.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "from gdsfactory.generic_tech import LAYER_STACK, get_generic_pdk\n",
+    "from gdsfactory.gpdk import LAYER_STACK, get_generic_pdk\n",
     "\n",
     "import gplugins.lumerical as sim\n",
     "\n",

--- a/notebooks/meep_01_sparameters.ipynb
+++ b/notebooks/meep_01_sparameters.ipynb
@@ -108,7 +108,7 @@
     "import matplotlib.pyplot as plt\n",
     "import meep as mp\n",
     "import numpy as np\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "from meep import MaterialGrid, Medium, Vector3, Volume\n",
     "from meep.adjoint import (\n",
     "    DesignRegion,\n",

--- a/notebooks/meep_02_gratings.ipynb
+++ b/notebooks/meep_02_gratings.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "\n",
     "import gplugins as sim\n",
     "import gplugins.gmeep as gm\n",

--- a/notebooks/meow_01.ipynb
+++ b/notebooks/meow_01.ipynb
@@ -24,7 +24,7 @@
     "import gdsfactory as gf\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "\n",
     "from gplugins.meow import MEOW\n",
     "\n",

--- a/notebooks/mode_solver_fdfd.ipynb
+++ b/notebooks/mode_solver_fdfd.ipynb
@@ -29,7 +29,7 @@
     "import gplugins.tidy3d as gt\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "\n",
     "gf.config.rich_output()\n",
     "PDK = get_generic_pdk()\n",

--- a/notebooks/palace_01_electrostatic.ipynb
+++ b/notebooks/palace_01_electrostatic.ipynb
@@ -45,7 +45,7 @@
     "from gdsfactory.components.analog.interdigital_capacitor import (\n",
     "    interdigital_capacitor,\n",
     ")\n",
-    "from gdsfactory.generic_tech import LAYER, get_generic_pdk\n",
+    "from gdsfactory.gpdk import LAYER, get_generic_pdk\n",
     "from gdsfactory.technology import LayerStack\n",
     "from gdsfactory.technology.layer_stack import LayerLevel\n",
     "from IPython.display import display\n",

--- a/notebooks/palace_02_fullwave.ipynb
+++ b/notebooks/palace_02_fullwave.ipynb
@@ -54,7 +54,7 @@
     "import pyvista as pv\n",
     "import skrf\n",
     "from gdsfactory.components.interdigital_capacitor import interdigital_capacitor\n",
-    "from gdsfactory.generic_tech import LAYER, get_generic_pdk\n",
+    "from gdsfactory.gpdk import LAYER, get_generic_pdk\n",
     "from gdsfactory.technology import LayerStack\n",
     "from gdsfactory.technology.layer_stack import LayerLevel\n",
     "from IPython.display import display\n",

--- a/notebooks/ray_optimiser.ipynb
+++ b/notebooks/ray_optimiser.ipynb
@@ -36,7 +36,7 @@
     "import ray.air\n",
     "import ray.air.session\n",
     "from gdsfactory.config import PATH\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "from ray import tune\n",
     "from ray.tune.search.hyperopt import HyperOptSearch\n",
     "\n",

--- a/notebooks/sax_01_sax.ipynb
+++ b/notebooks/sax_01_sax.ipynb
@@ -39,7 +39,7 @@
     "import meow as mw\n",
     "import numpy as np\n",
     "import sax\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "from numpy.fft import fft2, fftfreq, fftshift, ifft2\n",
     "from rich.logging import RichHandler\n",
     "from scipy import constants\n",

--- a/notebooks/tidy3d_00_tidy3d.ipynb
+++ b/notebooks/tidy3d_00_tidy3d.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gdsfactory.generic_tech import LAYER_STACK, get_generic_pdk\n",
+    "from gdsfactory.gpdk import LAYER_STACK, get_generic_pdk\n",
     "\n",
     "pdk = get_generic_pdk()\n",
     "pdk.activate()\n",

--- a/notebooks/workflow_1_mzi.ipynb
+++ b/notebooks/workflow_1_mzi.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "import gdsfactory as gf\n",
     "import numpy as np\n",
-    "from gdsfactory.generic_tech import get_generic_pdk\n",
+    "from gdsfactory.gpdk import get_generic_pdk\n",
     "\n",
     "gf.config.rich_output()\n",
     "PDK = get_generic_pdk()\n",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Migrate imports from gdsfactory.generic_tech to gdsfactory.gpdk across plugins and notebooks to align with the updated generic PDK API and remove usage of deprecated modules.