### PR TITLE
fix: support canonical material aliases

### DIFF
--- a/gplugins/femwell/mode_solver.py
+++ b/gplugins/femwell/mode_solver.py
@@ -92,6 +92,9 @@ def compute_cross_section_modes(
 
 
 _material_name_to_index = {
+    "Si": 3.48,
+    "SiO2": 1.44,
+    "SiN": 2.0,
     "si": 3.48,
     "sio2": 1.44,
     "sin": 2.0,

--- a/gplugins/lumerical/write_sparameters_lumerical.py
+++ b/gplugins/lumerical/write_sparameters_lumerical.py
@@ -35,6 +35,23 @@ run=False returns the simulation session for you to debug and make sure it is co
 To compute the Sparameters you need to pass run=True
 """
 
+_MATERIAL_NAME_ALIASES = {
+    "Si": "si",
+    "SiO2": "sio2",
+    "SiN": "sin",
+}
+
+
+def _add_material_name_aliases(
+    material_mapping: dict[str, MaterialSpec],
+) -> None:
+    """Add missing canonical or legacy aliases without overriding mappings."""
+    for canonical_name, legacy_name in _MATERIAL_NAME_ALIASES.items():
+        if canonical_name in material_mapping:
+            material_mapping.setdefault(legacy_name, material_mapping[canonical_name])
+        elif legacy_name in material_mapping:
+            material_mapping[canonical_name] = material_mapping[legacy_name]
+
 
 def set_material(session, structure: str, material: MaterialSpec) -> None:
     """Sets the material of a structure.
@@ -379,6 +396,7 @@ def write_sparameters_lumerical(
     material_name_to_lumerical_new = material_name_to_lumerical or {}
     material_name_to_lumerical = ss.material_name_to_lumerical.copy()
     material_name_to_lumerical.update(**material_name_to_lumerical_new)
+    _add_material_name_aliases(material_name_to_lumerical)
 
     material = material_name_to_lumerical[ss.background_material]
     set_material(session=s, structure="clad", material=material)

--- a/gplugins/tidy3d/component.py
+++ b/gplugins/tidy3d/component.py
@@ -43,10 +43,17 @@ from gplugins.tidy3d.util import get_mode_solvers, get_port_normal, sort_layers
 
 PathType = pathlib.Path | str
 
+_silicon_medium = td.Medium(name="Si", permittivity=3.47**2)
+_silicon_dioxide_medium = td.Medium(name="SiO2", permittivity=1.47**2)
+_silicon_nitride_medium = td.Medium(name="SiN", permittivity=2.0**2)
+
 material_name_to_medium = {
-    "si": td.Medium(name="Si", permittivity=3.47**2),
-    "sio2": td.Medium(name="SiO2", permittivity=1.47**2),
-    "sin": td.Medium(name="SiN", permittivity=2.0**2),
+    "Si": _silicon_medium,
+    "SiO2": _silicon_dioxide_medium,
+    "SiN": _silicon_nitride_medium,
+    "si": _silicon_medium,
+    "sio2": _silicon_dioxide_medium,
+    "sin": _silicon_nitride_medium,
 }
 
 home = pathlib.Path.home()

--- a/gplugins/tidy3d/materials.py
+++ b/gplugins/tidy3d/materials.py
@@ -7,10 +7,17 @@ import tidy3d as td
 from tidy3d.components.medium import PoleResidue
 from tidy3d.components.types import Complex
 
+_silicon_medium = td.material_library["cSi"]["Li1993_293K"]
+_silicon_dioxide_medium = td.material_library["SiO2"]["Palik_Lossless"]
+_silicon_nitride_medium = td.material_library["Si3N4"]["Luke2015PMLStable"]
+
 material_name_to_tidy3d = {
-    "si": td.material_library["cSi"]["Li1993_293K"],
-    "sio2": td.material_library["SiO2"]["Palik_Lossless"],
-    "sin": td.material_library["Si3N4"]["Luke2015PMLStable"],
+    "Si": _silicon_medium,
+    "SiO2": _silicon_dioxide_medium,
+    "SiN": _silicon_nitride_medium,
+    "si": _silicon_medium,
+    "sio2": _silicon_dioxide_medium,
+    "sin": _silicon_nitride_medium,
 }
 
 MaterialSpecTidy3d: TypeAlias = (


### PR DESCRIPTION
Add canonical `Si`, `SiO2`, and `SiN` aliases to the default Femwell and Tidy3D material mappings used by PDK layer stacks.

Complete missing canonical or legacy aliases in Lumerical without overriding explicit mappings. Existing lowercase aliases remain supported, while film-qualified tokens still require explicit material mappings.

## Summary by Sourcery

Support canonical silicon material aliases across simulators without breaking existing mappings.

New Features:
- Add canonical `Si`, `SiO2`, and `SiN` aliases to Femwell, Tidy3D, and Lumerical material mappings while preserving lowercase aliases.

Bug Fixes:
- Ensure missing canonical or legacy silicon material names in Lumerical are automatically mapped to existing materials without overriding explicit configurations.