### PR TITLE
fix: restrict tbump version replacements

### DIFF
--- a/.changelog.d/761.fixed
+++ b/.changelog.d/761.fixed
@@ -1,0 +1,1 @@
+Prevent tbump from modifying dependency constraints during package version bumps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,12 +170,15 @@ cmd = "grep -q -F {new_version} CHANGELOG.md"
 name = "create & check changelog"
 
 [[tool.tbump.file]]
+search = '^# gplugins {current_version}$'
 src = "README.md"
 
 [[tool.tbump.file]]
+search = '^version = "{current_version}"$'
 src = "pyproject.toml"
 
 [[tool.tbump.file]]
+search = '^__version__ = "{current_version}"$'
 src = "gplugins/__init__.py"
 
 [tool.tbump.git]


### PR DESCRIPTION
Prevent tbump from changing dependency constraints that happen to match the package version.\n\nThe per-file search patterns now target only the package-version declarations.