### PR TITLE
fix(lumerical): retain ports outside layer stack

### DIFF
--- a/.changelog.d/764.fixed
+++ b/.changelog.d/764.fixed
@@ -1,1 +1,1 @@
-Lumerical simulations now skip optical ports on layers absent from the simulation LayerStack.
+Lumerical simulations now keep optical ports on layers absent from the simulation LayerStack.

--- a/.changelog.d/765.fixed
+++ b/.changelog.d/765.fixed
@@ -1,0 +1,1 @@
+Lumerical mode ports on layers absent from the simulation LayerStack now use the component vertical extent.

--- a/gplugins/lumerical/tests/test_write_sparameters_lumerical.py
+++ b/gplugins/lumerical/tests/test_write_sparameters_lumerical.py
@@ -39,7 +39,7 @@ class _Session:
         pass
 
 
-def test_skips_ports_on_layers_not_in_layer_stack(monkeypatch, tmp_path) -> None:
+def test_keeps_ports_on_layers_not_in_layer_stack(monkeypatch, tmp_path) -> None:
     monkeypatch.setitem(sys.modules, "lumapi", ModuleType("lumapi"))
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 1), (0, 1)], layer=(1, 0))
@@ -75,4 +75,4 @@ def test_skips_ports_on_layers_not_in_layer_stack(monkeypatch, tmp_path) -> None
     )
 
     assert result is session
-    assert session.ports == 1
+    assert session.ports == 2

--- a/gplugins/lumerical/write_sparameters_lumerical.py
+++ b/gplugins/lumerical/write_sparameters_lumerical.py
@@ -381,29 +381,6 @@ def write_sparameters_lumerical(
     component_thickness = max(layers_thickness)
     component_zmin = min(layers_zmin)
 
-    ports_without_layer_stack = [
-        port
-        for port in ports
-        if gf.get_layer(port.layer) not in index_to_thickness
-        or gf.get_layer(port.layer) not in index_to_zmin
-    ]
-    if ports_without_layer_stack:
-        logger.warning(
-            "Skipping optical ports on layers not defined in the layer stack: %s",
-            ", ".join(port.name for port in ports_without_layer_stack),
-        )
-    ports = [
-        port
-        for port in ports
-        if gf.get_layer(port.layer) in index_to_thickness
-        and gf.get_layer(port.layer) in index_to_zmin
-    ]
-    if not ports:
-        raise ValueError(
-            f"{component.name!r} does not have any optical ports on layers "
-            "defined in the layer stack"
-        )
-
     z = (component_zmin + component_thickness) / 2 * 1e-6
     z_span = (2 * zmargin + component_thickness) * 1e-6
 
@@ -535,8 +512,14 @@ def write_sparameters_lumerical(
 
     for i, port in enumerate(ports):
         port_layer_index = gf.get_layer(port.layer)
-        zmin = index_to_zmin[port_layer_index]
-        thickness = index_to_thickness[port_layer_index]
+        zmin = index_to_zmin.get(port_layer_index, component_zmin)
+        thickness = index_to_thickness.get(port_layer_index, component_thickness)
+        if port_layer_index not in index_to_thickness:
+            logger.warning(
+                "Port %r is on a layer not defined in the layer stack; using the "
+                "component vertical extent for its mode port",
+                port.name,
+            )
         z = (zmin + thickness) / 2
         zspan = 2 * ss.port_margin + thickness
 


### PR DESCRIPTION
## Summary
- retain all optical ports, including ports on layers absent from the simulation LayerStack
- use the component vertical extent for mode ports on undefined layers
- retain the existing behavior of skipping undefined geometry layers during Lumerical import

## Validation
- `uv run pytest gplugins/lumerical/tests/test_write_sparameters_lumerical.py gplugins/lumerical/tests/test_background_layers.py gplugins/lumerical/tests/test_netlist.py gplugins/lumerical/tests/test_netlist_get_routes.py -q`
- `uv run ruff check gplugins/lumerical/write_sparameters_lumerical.py gplugins/lumerical/tests/test_write_sparameters_lumerical.py`
- `uv run ruff format --check gplugins/lumerical/write_sparameters_lumerical.py gplugins/lumerical/tests/test_write_sparameters_lumerical.py`

## Summary by Sourcery

Retain optical ports on layers not defined in the Lumerical simulation layer stack while preserving existing handling of undefined geometry layers.

Bug Fixes:
- Ensure mode ports on layers absent from the layer stack use the component vertical extent instead of being skipped.

Tests:
- Update Lumerical s-parameters test to expect ports on undefined layers to be kept rather than discarded.

Chores:
- Add changelog entry documenting the Lumerical port handling fix.