### PR TITLE
fix(lumerical): extend ports beyond PML

### DIFF
--- a/.changelog.d/766.fixed
+++ b/.changelog.d/766.fixed
@@ -1,0 +1,1 @@
+Lumerical port waveguides now extend beyond the FDTD PML when simulation margins are configured.

--- a/gplugins/lumerical/tests/test_write_sparameters_lumerical.py
+++ b/gplugins/lumerical/tests/test_write_sparameters_lumerical.py
@@ -10,6 +10,8 @@ from gplugins.lumerical.write_sparameters_lumerical import write_sparameters_lum
 class _Session:
     def __init__(self) -> None:
         self.ports = 0
+        self.fdtd_settings: dict[str, object] = {}
+        self.gdspath: str | None = None
 
     def newproject(self) -> None:
         pass
@@ -27,10 +29,10 @@ class _Session:
         pass
 
     def addfdtd(self, **kwargs: object) -> None:
-        pass
+        self.fdtd_settings = kwargs
 
     def gdsimport(self, *args: object) -> None:
-        pass
+        self.gdspath = str(args[0])
 
     def addport(self) -> None:
         self.ports += 1
@@ -76,3 +78,30 @@ def test_keeps_ports_on_layers_not_in_layer_stack(monkeypatch, tmp_path) -> None
 
     assert result is session
     assert session.ports == 2
+
+
+def test_port_extension_reaches_beyond_pml(monkeypatch, tmp_path) -> None:
+    monkeypatch.setitem(sys.modules, "lumapi", ModuleType("lumapi"))
+    component = gf.components.straight(length=10, cross_section="strip")
+    layer_stack = LayerStack(
+        layers={
+            "core": LayerLevel(layer=(1, 0), thickness=0.22, zmin=0, material="sio2")
+        }
+    )
+    session = _Session()
+
+    write_sparameters_lumerical(
+        component,
+        session=session,
+        run=False,
+        dirpath=tmp_path,
+        layer_stack=layer_stack,
+        xmargin=2,
+        ymargin=0,
+        port_extension=1,
+    )
+
+    assert session.gdspath is not None
+    exported_component = gf.import_gds(session.gdspath)
+    assert exported_component.xmin < session.fdtd_settings["x_min"] * 1e6
+    assert exported_component.xmax > session.fdtd_settings["x_max"] * 1e6

--- a/gplugins/lumerical/write_sparameters_lumerical.py
+++ b/gplugins/lumerical/write_sparameters_lumerical.py
@@ -306,8 +306,14 @@ def write_sparameters_lumerical(
     if not ports:
         raise ValueError(f"{component.name!r} does not have any optical ports")
 
+    # The FDTD bounds add the requested margins around ``component_extended``.
+    # Include that headroom in the physical extension so every waveguide reaches
+    # beyond the PML, regardless of port orientation.
+    port_extension_beyond_pml = ss.port_extension + max(
+        xmargin_left, xmargin_right, ymargin_top, ymargin_bot
+    )
     component_extended_beyond_pml = gf.components.extension.extend_ports(
-        component=component_extended, length=ss.port_extension
+        component=component_extended, length=port_extension_beyond_pml
     )
     component_extended_beyond_pml = component_extended_beyond_pml.copy()
     component_extended_beyond_pml.flatten()


### PR DESCRIPTION
## Summary
- include per-side FDTD margins in the physical port extension length
- ensure exported waveguides extend beyond the PML for every port orientation
- add a regression test comparing exported GDS and FDTD bounds

## Validation
- `uv run pytest gplugins/lumerical/tests/test_write_sparameters_lumerical.py gplugins/lumerical/tests/test_background_layers.py gplugins/lumerical/tests/test_netlist.py gplugins/lumerical/tests/test_netlist_get_routes.py -q`
- `uv run ruff check gplugins/lumerical/write_sparameters_lumerical.py gplugins/lumerical/tests/test_write_sparameters_lumerical.py`
- `uv run ruff format --check gplugins/lumerical/write_sparameters_lumerical.py gplugins/lumerical/tests/test_write_sparameters_lumerical.py`

## Summary by Sourcery

Extend exported waveguides so that all ports reach beyond the FDTD PML margins and add coverage via regression testing.

Bug Fixes:
- Ensure physical port extensions include per-side FDTD margins so exported waveguides reach beyond the PML for all port orientations.

Tests:
- Add a regression test verifying that the exported GDS geometry extends beyond the simulated FDTD bounds for configured margins.