### PR TITLE
fix: make gplugins.tidy3d importable with gdsfactory 9.x

### DIFF
--- a/.github/.lychee.toml
+++ b/.github/.lychee.toml
@@ -46,7 +46,12 @@ exclude = [
   "https://meep.readthedocs.io/.*",
   "https://gdsfactory.github.io/gdsfactory/.*",
   # PeerTube instance has an expired TLS certificate
-  "https://peertube.f-si.org/.*"
+  "https://peertube.f-si.org/.*",
+  # Optica blocks automated crawlers; DOIs in the 10.1364 prefix redirect there
+  "https://opg.optica.org/.*",
+  "https://doi.org/10.1364/.*",
+  # srim.org is intermittently unreachable and times out
+  "http://www.srim.org/.*"
 ]
 # Exclude paths that contain template variables or are known false positives
 exclude_path = [

--- a/gplugins/tidy3d/modes.py
+++ b/gplugins/tidy3d/modes.py
@@ -23,7 +23,6 @@ import tidy3d as td
 import xarray
 from gdsfactory import logger
 from gdsfactory.config import PATH
-from gdsfactory.typings import PathType
 from pydantic.v1 import BaseModel
 from tidy3d.plugins import waveguide
 from tqdm.auto import tqdm
@@ -155,7 +154,9 @@ class Waveguide(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     precision: Precision = "double"
     grid_resolution: int = 20
     max_grid_scaling: float = 1.2
-    cache_path: PathType | None = PATH.modes
+    # PathType is a PEP 695 type alias, which pydantic v1 cannot introspect,
+    # so the union is spelled out here.
+    cache_path: str | pathlib.Path | None = PATH.modes
     overwrite: bool = False
 
     _cached_data = pydantic.PrivateAttr()


### PR DESCRIPTION
Fixes #769

## Problem

`import gplugins.tidy3d` raises at import time on gdsfactory 9.x:

```
RuntimeError: error checking inheritance of PathType (type: TypeAliasType)
```

`Waveguide` is a `pydantic.v1.BaseModel`, and its `cache_path` field was annotated with `gdsfactory.typings.PathType`, which is now a PEP 695 alias (`type PathType = str | pathlib.Path`). Pydantic v1 cannot introspect `TypeAliasType`, so field construction blows up and the whole plugin becomes unimportable.

## Fix

Spell the union out in the v1 model and drop the now-unused import. The other `PathType` uses in `gplugins/tidy3d/` are plain function annotations, which are never introspected, so they are left alone.

## Verification

With gdsfactory 9.49.0 / gplugins 2.1.4, before the change the import raises; after it:

```python
import gplugins.tidy3d as gt
w = gt.modes.Waveguide(
    wavelength=1.31, core_width=0.5, core_thickness=0.22, slab_thickness=0.0,
    core_material="si", clad_material="sio2", grid_resolution=20, overwrite=True,
)
w.n_eff          # [2.71333363+0.j 2.16974811+0.j]
type(w.cache_path)  # pathlib.PosixPath  (str still coerces, None still disables the cache)
```

`pre-commit run --files gplugins/tidy3d/modes.py` passes.

## Summary by Sourcery

Make the Tidy3D plugin importable with gdsfactory 9.x while preserving Waveguide cache path support.

Bug Fixes:
- Restore importability of the Tidy3D plugin with gdsfactory 9.x by making its Pydantic model compatible with the newer path type alias behavior.

Chores:
- Expand lychee URL exclusions for intermittently inaccessible or crawler-blocking external sites.